### PR TITLE
[doc] Update for JetBrains 0.9.1 (release/0.9) and VS Code 0.1.0 (rel…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,17 +15,17 @@ hide:
 
     Full IntelliJ Platform plugin — multi-tab `.wasm` editor, WAT and WIT language support, MCP server with 17 tools, Java-side completion for GraalWasm and Chicory, JavaScript / TypeScript type inference for `WebAssembly.instantiate`, run and debug on Wasmtime / WAMR / GraalVM.
 
-    **Current release**: 0.9 (2026-05-07)
+    **Current release**: 0.9.1 (2026-05-20) — 0.9 line, initial 0.9 on 2026-05-07
     Supported IDEs: IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
 
     [Read the docs →](jetbrains/index.md)
 
 -   ### For Visual Studio Code
 
-    VS Code extension with a Compose-for-Web custom editor, virtual-scrolling hex viewer, 11 structural-analysis tabs, Component Model dependency resolution, and Wasmtime run support.
+    VS Code extension with a Compose-for-Web custom editor, virtual-scrolling hex viewer, 11 structural-analysis tabs, Component Model dependency resolution, experimental debugging, an on-demand MCP server, and Run on Wasmtime / WAMR / GraalVM.
 
-    **Current release**: 0.0.2 preview
-    Supports: VS Code 1.85+, Cursor, VSCodium, Code OSS, and other VS Code-based editors via Open VSX.
+    **Current release**: 0.1.0 preview (2026-05-20)
+    Supports: VS Code 1.102+, Cursor, VSCodium, Code OSS, and other VS Code-based editors via Open VSX.
 
     [Read the docs →](vscode/index.md)
 
@@ -45,12 +45,12 @@ Hexana's WASM analysis core is a single Kotlin Multiplatform codebase used by bo
 | You want… | Use |
 |---|---|
 | The deepest WIT editing experience | JetBrains plugin |
-| MCP server for AI assistants | JetBrains plugin |
+| MCP server for AI assistants | Both — bundled in JetBrains plugin; on-demand download in VS Code extension since 0.1.0 |
 | Java-side completion (GraalWasm, Chicory) | JetBrains plugin |
 | JS / TS `WebAssembly.instantiate` type inference | JetBrains plugin |
-| Debugger with breakpoints | JetBrains plugin |
-| DWARF source mapping | JetBrains plugin |
-| Run on WAMR or GraalVM | JetBrains plugin |
+| Debugger with breakpoints | Both — JetBrains plugin since 0.9; VS Code extension experimentally since 0.1.0 |
+| DWARF source mapping | Both |
+| Run on WAMR or GraalVM | Both since VS Code 0.1.0 |
 | Lightweight `.wasm` inspector in VS Code | VS Code extension |
 | Compose-for-Web custom editor in VS Code / Cursor / VSCodium | VS Code extension |
 | Use Hexana from Cursor or VSCodium | VS Code extension |

--- a/docs/jetbrains/changelog-0.9.md
+++ b/docs/jetbrains/changelog-0.9.md
@@ -1,15 +1,30 @@
 ---
 title: Hexana 0.9 Release Notes
-description: Pinned release notes for Hexana 0.9 (2026-05-07).
-version: "0.9"
-released: 2026-05-07
+description: Pinned release notes for the Hexana 0.9.x line (0.9 released 2026-05-07, 0.9.1 released 2026-05-20).
+version: "0.9.1"
+released: 2026-05-20
 ---
 
-# Hexana 0.9 Release Notes
+# Hexana 0.9.x Release Notes
 
-Released **2026-05-07**.
+Current line: **0.9.1**, released **2026-05-20**. Initial 0.9 release: **2026-05-07**.
+
+## What's new in 0.9.1
+
+Released **2026-05-20**. Patch release on top of 0.9.
+
+### Added
+
+- **`.wit` and `.wasm` exports in Goto Symbol / Search Everywhere → Symbols.** `.wit` declarations (interfaces, worlds, functions, types) and Component Model exports are now indexed alongside regular `.wasm` module exports. Picking a `.wasm` export opens the containing binary and selects the matching row in the **Exports** tab.
+
+### Changed
+
+- **Build toolchain bumped to Java 21** for the plugin's compile target, aligning with the IntelliJ Platform 2024.3+ baseline. No behaviour change for users on supported IDE builds.
+- **IntelliJ Driver dependency** updated to `261.22158.277` for the UI-driver test slice (does not affect the shipped plugin).
 
 ## What's new in 0.9
+
+Released **2026-05-07**.
 
 ### Added
 

--- a/docs/jetbrains/index.md
+++ b/docs/jetbrains/index.md
@@ -1,14 +1,14 @@
 ---
-title: Hexana IntelliJ Plugin — Documentation (0.9)
-description: User and contributor documentation for the Hexana IntelliJ Platform plugin, version 0.9 (released 2026-05-07).
-version: "0.9"
-released: 2026-05-07
+title: Hexana IntelliJ Plugin — Documentation (0.9.x)
+description: User and contributor documentation for the Hexana IntelliJ Platform plugin, 0.9 line (0.9 released 2026-05-07, 0.9.1 released 2026-05-20).
+version: "0.9.1"
+released: 2026-05-20
 audience: [users]
 ---
 
 # Hexana — IntelliJ Plugin Documentation
 
-**Hexana** is an IntelliJ Platform plugin (plugin ID `org.jetbrains.hexana`, vendor JetBrains) for WebAssembly and binary analysis. It parses `.wasm` modules, renders WAT and WIT, integrates with WASM runtimes (Wasmtime, WAMR, GraalVM), exposes a Model Context Protocol (MCP) server for AI-assisted exploration, and ships Java-side code completion for the GraalWasm and Chicory APIs. This documentation set describes **release 0.9** (2026-05-07).
+**Hexana** is an IntelliJ Platform plugin (plugin ID `org.jetbrains.hexana`, vendor JetBrains) for WebAssembly and binary analysis. It parses `.wasm` modules, renders WAT and WIT, integrates with WASM runtimes (Wasmtime, WAMR, GraalVM), exposes a Model Context Protocol (MCP) server for AI-assisted exploration, and ships Java-side code completion for the GraalWasm and Chicory APIs. This documentation set describes the **0.9.x** line — initial **0.9** release on 2026-05-07 and **0.9.1** patch on 2026-05-20.
 
 ## What's in this directory
 
@@ -24,12 +24,12 @@ audience: [users]
 | [`js-integration.md`](js-integration.md) | JS / TS users | `WebAssembly.instantiate` imports completion and `.instance.exports` type inference. |
 | [`settings.md`](settings.md) | Users | `Settings → Tools → Hexana` and `Settings → Build, Execution → WASM Runtime`. |
 | [`troubleshooting.md`](troubleshooting.md) | Users | Common failure modes and resolutions. |
-| [`changelog-0.9.md`](changelog-0.9.md) | All | Release notes for 0.9, pinned. |
+| [`changelog-0.9.md`](changelog-0.9.md) | All | Release notes for the 0.9.x line (0.9, 0.9.1), pinned. |
 | [`llms.txt`](../llms.txt) | LLM agents | Curated index for AI assistants reading the docs. |
 
 ## Version and compatibility
 
-- **Plugin version**: 0.9 (built from `release/0.9` branch, commit `6a108799`).
+- **Plugin version**: 0.9.1 (built from `release/0.9` branch, commit `9a615b34`; initial 0.9 cut at `6a108799`).
 - **`since-build`**: defined by `gradle.properties` → `defaultSinceBuild`. Hexana targets IntelliJ Platform 2024.1+.
 - **Optional integrations**: the JavaScript plugin (enables JS interop for `instance.exports`) and the Java module (enables GraalWasm / Chicory completion). Both are loaded when the host IDE bundles them.
 - **Required dependency**: `com.intellij.mcpServer` — Hexana registers its toolset against the platform MCP server.
@@ -49,4 +49,4 @@ A companion **VS Code extension** is published separately on `marketplace.visual
 
 ## Source of truth
 
-This documentation set describes the **0.9** release. For unreleased work, see `idea-plugin/CHANGELOG.md` in the repository root. For the master-branch state, see commit history after `6a108799`.
+This documentation set describes the **0.9.x** line, currently **0.9.1**. For unreleased work, see `idea-plugin/CHANGELOG.md` in the repository root. For the master-branch state, see commit history after `9a615b34`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,11 +1,11 @@
 # Hexana — WebAssembly and Binary Analysis
 
-> Hexana is a WebAssembly and binary analysis toolkit by JetBrains, available as an IntelliJ Platform plugin (`org.jetbrains.hexana`) and a VS Code extension (`JetBrains.hexana-wasm`). It parses `.wasm` binaries, renders WAT and WIT, integrates with WASM runtimes (Wasmtime, WAMR, GraalVM), exposes Model Context Protocol tools, and supports Component Model dependency resolution. This index covers both products as of 2026-05.
+> Hexana is a WebAssembly and binary analysis toolkit by JetBrains, available as an IntelliJ Platform plugin (`org.jetbrains.hexana`) and a VS Code extension (`JetBrains.hexana-wasm`). It parses `.wasm` binaries, renders WAT and WIT, integrates with WASM runtimes (Wasmtime, WAMR, GraalVM), exposes Model Context Protocol tools, supports Component Model dependency resolution, and provides experimental WASM debugging via `lldb`. This index covers both products as of 2026-05-20.
 
 ## Products
 
-- **JetBrains IDE plugin** — version 0.9, released 2026-05-07. Source branch `release/0.9`. Compatible with IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
-- **VS Code extension** — version 0.0.2 preview. Source branch `release/vscode-0.0.2`. Compatible with VS Code 1.85+, Cursor, VSCodium, Code OSS.
+- **JetBrains IDE plugin** — version 0.9.1, released 2026-05-20 (0.9 line; initial 0.9 on 2026-05-07). Source branch `release/0.9`. Compatible with IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
+- **VS Code extension** — version 0.1.0 preview, released 2026-05-20. Source branch `release/vscode-0.1.0`. Compatible with VS Code 1.102+, Cursor, VSCodium, Code OSS.
 
 ## Identity
 
@@ -23,7 +23,7 @@
 
 - [Home](index.md): product overview and routing between JetBrains and VS Code documentation.
 
-## Docs — JetBrains IDE plugin (0.9)
+## Docs — JetBrains IDE plugin (0.9.x)
 
 - [Overview](jetbrains/index.md): documentation landing for the JetBrains plugin.
 - [Getting Started](jetbrains/getting-started.md): install, open a .wasm, find the main views.
@@ -36,25 +36,25 @@
 - [JS and TS Integration](jetbrains/js-integration.md): WebAssembly.instantiate imports completion and .instance.exports type inference.
 - [Settings](jetbrains/settings.md): IDE settings pages.
 - [Troubleshooting](jetbrains/troubleshooting.md): common failure modes and resolutions.
-- [Changelog 0.9](jetbrains/changelog-0.9.md): pinned release notes for 0.9.
+- [Changelog 0.9](jetbrains/changelog-0.9.md): pinned release notes for the 0.9.x line (0.9, 0.9.1).
 
-## Docs — VS Code extension (0.0.2)
+## Docs — VS Code extension (0.1.0)
 
 - [Overview](vscode/index.md): documentation landing for the VS Code extension.
 - [Getting Started](vscode/getting-started.md): install, open a .wasm, find the main panels.
 - [Features](vscode/features.md): complete capability reference.
 - [Analysis Tabs](vscode/analysis-tabs.md): per-tab reference for all 11 analysis panels.
-- [Run Support](vscode/run-support.md): running Core Wasm and Component Model binaries through Wasmtime.
+- [Run and Debug](vscode/run-support.md): running and debugging Core Wasm and Component Model binaries through Wasmtime, WAMR, or GraalVM.
 - [Component Model](vscode/component-model.md): dependency resolution and nested-module navigation.
-- [Settings](vscode/settings.md): the two VS Code settings the extension contributes.
+- [Settings](vscode/settings.md): the three VS Code settings the extension contributes.
 - [Troubleshooting](vscode/troubleshooting.md): common failure modes and resolutions.
-- [Changelog](vscode/changelog.md): release notes.
+- [Changelog](vscode/changelog.md): release notes (0.0.1 → 0.1.0).
 
 ## FAQ
 
 ### What is Hexana?
 
-Hexana is a WebAssembly and binary analysis toolkit by JetBrains, available as an IntelliJ Platform plugin and a VS Code extension. Both products parse `.wasm` binaries (Core Wasm and Component Model), render WAT, list imports / exports / functions / types / data / custom sections, profile binary size, and run modules through Wasmtime. The JetBrains plugin additionally ships WIT language support, an MCP server with 17 tools, Java-side completion (GraalWasm, Chicory), JavaScript / TypeScript type inference (`WebAssembly.instantiate`), a debugger, and DWARF-based source mapping. The VS Code extension is a lighter-weight inspector with a Compose-for-Web custom editor and 11 structural-analysis tabs.
+Hexana is a WebAssembly and binary analysis toolkit by JetBrains, available as an IntelliJ Platform plugin and a VS Code extension. Both products parse `.wasm` binaries (Core Wasm and Component Model), render WAT, list imports / exports / functions / types / data / custom sections, profile binary size, run modules through Wasmtime / WAMR / GraalVM, and (as of JetBrains 0.9 and VS Code 0.1.0) debug via `lldb`. The JetBrains plugin additionally ships full WIT language support, an in-process MCP server with 17 tools, Java-side completion (GraalWasm, Chicory), JavaScript / TypeScript type inference (`WebAssembly.instantiate`), and Goto-Symbol integration for `.wit` and `.wasm` exports. The VS Code extension is a lighter-weight inspector with a Compose-for-Web custom editor, 11 structural-analysis tabs, and an on-demand-downloaded MCP server (since 0.1.0).
 
 ### How do I install Hexana?
 
@@ -66,7 +66,7 @@ Yes. Both products are free. Source code is open at github.com/JetBrains/hexana.
 
 ### Which IDEs are supported?
 
-IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm, and any IntelliJ-based IDE on platform 2024.1+ that bundles the MCP server plugin. Plus Visual Studio Code 1.85+ and VS Code-based editors (Cursor, VSCodium, Code OSS, Windsurf).
+IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm, and any IntelliJ-based IDE on platform 2024.1+ that bundles the MCP server plugin. Plus Visual Studio Code 1.102+ (since VS Code extension 0.1.0) and VS Code-based editors (Cursor, VSCodium, Code OSS, Windsurf) at the same baseline. Earlier VS Code 1.85+ ran the 0.0.x line.
 
 ### Does Hexana support the Component Model?
 
@@ -74,15 +74,15 @@ Yes. Both products detect Component Model binaries, list their nested modules, a
 
 ### Does Hexana have an MCP server?
 
-The JetBrains plugin exposes 17 Model Context Protocol tools (`summarize_module`, `list_imports`, `list_exports`, `list_functions`, `get_instructions_for_functions`, `list_data`, and more) through the platform MCP server. AI assistants like Claude Desktop, Claude Code, Cursor's agent mode, and Continue can call these to explore the loaded module. The VS Code extension does not ship an MCP server in 0.0.2.
+The JetBrains plugin exposes 17 Model Context Protocol tools (`summarize_module`, `list_imports`, `list_exports`, `list_functions`, `get_instructions_for_functions`, `list_data`, and more) through the platform MCP server. AI assistants like Claude Desktop, Claude Code, Cursor's agent mode, and Continue can call these to explore the loaded module. The VS Code extension ships the same MCP server since 0.1.0, downloaded on demand from GitHub Releases the first time an MCP client requests it; a Java 21+ JDK is required to launch it (`hexana.mcp.javaHome` setting lets you pin one).
 
 ### Does Hexana support debugging?
 
-Yes, in the JetBrains plugin (experimental as of 0.9). Works with Wasmtime and WAMR runtimes, requires LLVM 22.1 or newer, uses LLDB under the hood. Set breakpoints in the WAT view; they are mapped to source via DWARF when available. The VS Code extension does not have a debugger in 0.0.2.
+Yes — experimental in both products. JetBrains plugin since 0.9; VS Code extension since 0.1.0. Works with Wasmtime and WAMR runtimes, requires LLVM 22.1 or newer, uses `lldb` under the hood. Set breakpoints in source files; they are mapped to PCs via DWARF when available. GraalVM debug is not yet wired in either product.
 
 ### Which WASM runtimes does Hexana support?
 
-JetBrains plugin: Wasmtime, WAMR, GraalVM. VS Code extension: Wasmtime only (0.0.2).
+JetBrains plugin: Wasmtime, WAMR, GraalVM. VS Code extension (since 0.1.0): Wasmtime, WAMR, GraalVM — pick at Run/Debug time via the runtime picker.
 
 ### Does Hexana auto-detect WASM proposals?
 
@@ -90,7 +90,7 @@ Yes. Both products detect which proposals a binary uses (Threads, SIMD, GC, Tail
 
 ### Does Hexana parse DWARF debug info?
 
-The JetBrains plugin parses DWARF v4 and v5 sections embedded in `.wasm` custom sections and uses them for source-line mapping in the debugger and for WAT→source navigation. The VS Code extension lists DWARF sections in the Custom tab but does not yet use them for navigation.
+The JetBrains plugin parses DWARF v4 and v5 sections embedded in `.wasm` custom sections and uses them for source-line mapping in the debugger and for WAT→source navigation. The VS Code extension uses DWARF for breakpoint resolution in the experimental debugger (since 0.1.0); the Custom tab also lists DWARF sections.
 
 ### Where is Hexana's source code?
 
@@ -100,4 +100,4 @@ github.com/JetBrains/hexana. Public, open-source. JetBrains plugin sources under
 
 - [GitHub repository](https://github.com/JetBrains/hexana): authoritative source code.
 - [JetBrains plugin `plugin.xml`](https://github.com/JetBrains/hexana/blob/release/0.9/idea-plugin/src/main/resources/META-INF/plugin.xml): authoritative IntelliJ extension and dependency declarations.
-- [VS Code extension `package.json`](https://github.com/JetBrains/hexana/blob/release/vscode-0.0.2/vscode-plugin/package.json): authoritative VS Code manifest.
+- [VS Code extension `package.json`](https://github.com/JetBrains/hexana/blob/release/vscode-0.1.0/vscode-plugin/package.json): authoritative VS Code manifest.

--- a/docs/vscode/analysis-tabs.md
+++ b/docs/vscode/analysis-tabs.md
@@ -1,7 +1,7 @@
 ---
-title: Hexana for VS Code — Analysis Tab Reference (0.0.2)
+title: Hexana for VS Code — Analysis Tab Reference (0.1.0)
 description: Per-tab reference for all 11 analysis panels inside the Hexana VS Code editor.
-version: "0.0.2"
+version: "0.1.0"
 ---
 
 # Analysis Tab Reference
@@ -163,7 +163,7 @@ Generates the **WebAssembly Text** representation of the loaded binary and opens
 
 The conversion runs in the webview via a WASM-based wat printer (`WasmPrinterJs`), so there is no external dependency.
 
-In 0.0.2 the WAT view is read-only and is regenerated on each open. Inline WAT editing — present in the JetBrains plugin since the editable-binary-documents arc — is not yet in the VS Code extension.
+In 0.1.0 the WAT view is read-only and is regenerated on each open. Inline WAT editing — present in the JetBrains plugin since the editable-binary-documents arc — is not yet in the VS Code extension.
 
 ## See also
 

--- a/docs/vscode/changelog.md
+++ b/docs/vscode/changelog.md
@@ -1,13 +1,45 @@
 ---
 title: Hexana for VS Code — Release Notes
 description: Release notes for the Hexana VS Code extension.
-version: "0.0.2"
-released: 2026-05
+version: "0.1.0"
+released: 2026-05-20
 ---
 
 # Release Notes — Hexana for VS Code
 
-This page tracks releases of the VS Code extension. The authoritative source is the commit history on the `release/vscode-0.0.2` and `release/vscode-0.0.1` branches in the repository.
+This page tracks releases of the VS Code extension. The authoritative source is the commit history on the `release/vscode-0.1.0`, `release/vscode-0.0.2`, and `release/vscode-0.0.1` branches in the repository.
+
+## 0.1.0 — preview
+
+Source branch: `release/vscode-0.1.0`. Released **2026-05-20**.
+
+First release in the `0.1.x` line. Still marked `preview` on the marketplace while the debug and MCP integrations stabilise.
+
+### Added
+
+- **Experimental WASM debugging.** Set breakpoints, step, and inspect local variables when running a module through Wasmtime or WAMR. Requires **LLVM 22.1 or newer**; uses `lldb` under the hood. Works only with targets debuggable through `lldb` (typically Rust, C/C++, and Emscripten builds with debug symbols). Supports debugging nested modules inside Component Model binaries (Wasmtime only). Breakpoints resolve across multiple source languages.
+- **Runtime picker for Run / Debug.** Choose between **Wasmtime**, **WAMR**, and **GraalVM** when launching a module. The Run / Debug dialog is always shown so you can pick the runtime and tweak arguments before execution.
+- **WAMR runtime support** for both running and debugging modules.
+- **GraalVM runtime support** with built-in detection of an installed GraalVM. Native-access warnings suppressed during execution.
+- **MCP server integration.** Hexana now ships a Model Context Protocol server that AI tools (Claude Desktop, Claude Code, Codex, etc.) can connect to for inspecting the currently open WASM file. The server is **downloaded on demand** from GitHub Releases on first use; subsequent launches re-use the cached install. Stale download locks are detected and recovered automatically.
+    - **`Hexana: Reinstall MCP Server` command** — re-runs the download to recover from a corrupted install or pin to a new release tag.
+    - **`hexana.mcp.javaHome` setting** — point Hexana at a specific Java runtime when `JAVA_HOME` / `PATH` do not surface a suitable JDK. Java 21 or newer is required for the MCP server to start.
+- **Submodule → parent backreference.** When you open a nested module inside a component, the editor toolbar shows a clickable link back to the containing component's editor tab. (Shared with the JetBrains plugin.)
+
+### Changed
+
+- **VS Code requirement raised to `^1.102.0`** to take advantage of the platform's stable MCP-server-registration API.
+- **Run / Debug dialog is now always shown** before launching a module — previously it was sometimes auto-dismissed on simple cases.
+- **Run-configuration logic deduplicated** between the VS Code extension and the JetBrains plugin; both products now share the same Kotlin core for command-line construction.
+- **Display name** on the marketplace remains `Hexana WebAssembly and Hex Viewer`; homepage URL points at `https://jetbrains.github.io/hexana/`.
+
+### Fixed
+
+- WAMR debugging stability fixes.
+- Path resolution for debug sessions (mapping source paths to compiled units).
+- Breakpoint resolution for nested-module scenarios.
+- Sorting-arrow rendering glitch in the analysis tables.
+- Various UI-test flakes; timeouts increased and editor-ready waits tightened.
 
 ## 0.0.2 — preview
 
@@ -16,7 +48,7 @@ Source branch: `release/vscode-0.0.2`.
 ### Added
 
 - **Setting to specify a custom Wasmtime path** (`hexana.wasmtimePath`) — for cases where Wasmtime is not on `PATH` or you want to pin to a specific build.
-- **Setting to disable statistics collection** (`hexana.enableStatistics`) — independent of VS Code's global telemetry toggle, both must be on for any event to be sent.
+- **Setting to disable statistics collection** (`hexana.enableStatistics`) — independent of VS Code's global telemetry toggle; both must be on for any event to be sent.
 - **Consent notice on first activation** — required disclosure of the anonymous analytics path.
 - **Submodule → parent backreference** in the editor toolbar — opening a nested module from a component shows a clickable link back to the containing component's editor tab.
 - **Marketplace listing improvements** — removed the broken image link, fixed the license link in the README, marked the extension as `preview`, refined the displayName and category list.
@@ -46,16 +78,28 @@ Initial public preview release. Shipped:
 
 ## Versioning policy
 
-The VS Code extension uses **`0.0.x` preview versioning** during the early life cycle to signal that contract changes (settings, editor URIs, etc.) may happen between releases. Versioning will shift to a stable cadence aligned with the JetBrains plugin once the surface stabilises (likely `0.1.0`+).
+The VS Code extension is in the **`0.1.x` preview** line as of 2026-05-20. The `preview` marketplace flag remains on while the debugging and MCP-server integrations stabilise. Contract changes (settings, editor URIs, MCP transport) may still happen between minor versions; we will call them out explicitly in this changelog.
+
+The `0.0.x` line is closed. New work targets `0.1.x`.
 
 ## Compatibility
 
-| VS Code version | Compatible? |
-|---|---|
-| 1.85+ | ✓ |
-| 1.84 and older | ✗ |
+| VS Code version | Compatible? | Notes |
+|---|---|---|
+| 1.102+ | ✓ | Required for 0.1.0 and later (MCP-server registration API). |
+| 1.85 – 1.101 | ✓ for 0.0.x only | 0.0.1 and 0.0.2 still work on 1.85+. |
+| 1.84 and older | ✗ | Missing Custom Editor + Webview APIs. |
 
-The extension targets the Custom Editor API + Webview API as those existed in 1.85 (December 2023). Older versions are missing required APIs.
+VS Code forks (Cursor, Code OSS / VSCodium, Windsurf, Continue.dev) are supported as long as they expose the equivalent VS Code APIs at the listed version. Some terminal- or filesystem-provider-dependent features may behave differently across forks.
+
+### Runtime requirements
+
+- **[wasmtime](https://wasmtime.dev/)** (optional) — needed for Run / Debug via Wasmtime.
+- **[WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)** (optional) — needed for Run / Debug via WAMR.
+- **[GraalVM](https://www.graalvm.org/) with GraalWasm** (optional) — needed for Run via GraalVM.
+- **[wasm-tools](https://github.com/bytecodealliance/wasm-tools)** or **[wac](https://github.com/bytecodealliance/wac)** (optional) — used for component composition when running Component Model binaries with unresolved imports.
+- **Java 21 or later** (optional) — needed for the Hexana MCP server. The server is downloaded on demand; set `hexana.mcp.javaHome` if Java is not available through `JAVA_HOME` or `PATH`.
+- **LLVM 22.1 or newer** (optional) — required for the experimental WASM debugging path.
 
 ## Distribution channels
 
@@ -65,5 +109,5 @@ The extension targets the Custom Editor API + Webview API as those existed in 1.
 
 ## See also
 
-- [`getting-started.md`](getting-started.md), [`features.md`](features.md).
+- [`getting-started.md`](getting-started.md), [`features.md`](features.md), [`run-support.md`](run-support.md), [`settings.md`](settings.md).
 - The JetBrains plugin's [changelog](../jetbrains/changelog-0.9.md).

--- a/docs/vscode/component-model.md
+++ b/docs/vscode/component-model.md
@@ -1,12 +1,12 @@
 ---
-title: Component Model Support in Hexana for VS Code (0.0.2)
+title: Component Model Support in Hexana for VS Code (0.1.0)
 description: How Hexana detects Component Model binaries, resolves their dependencies, composes them for execution, and navigates nested modules.
-version: "0.0.2"
+version: "0.1.0"
 ---
 
 # Component Model Support
 
-Hexana 0.0.2 has first-class support for **WebAssembly Component Model** binaries: it recognises them, lists their nested modules, resolves their imports against the workspace, and composes them for execution.
+Hexana 0.1.0 has first-class support for **WebAssembly Component Model** binaries: it recognises them, lists their nested modules, resolves their imports against the workspace, and composes them for execution.
 
 ## Detection
 
@@ -65,7 +65,7 @@ The implementation lives in `extension-lib/`, in `DependencyResolver.kt`, and is
 
 ### Workspace search scope
 
-By default, Hexana searches every `.wasm` file under every workspace folder, recursively. There is no setting to limit the search scope in 0.0.2; if performance becomes an issue on large workspaces, raise a tracker issue.
+By default, Hexana searches every `.wasm` file under every workspace folder, recursively. There is no setting to limit the search scope in 0.1.0; if performance becomes an issue on large workspaces, raise a tracker issue.
 
 Files in `.gitignore`, `node_modules`, `target`, and similar paths are **not** automatically excluded — Hexana looks at everything VS Code's workspace API exposes. If a stray `.wasm` in a build artifact directory accidentally matches an import, it may be picked up.
 
@@ -87,14 +87,15 @@ After resolution returns a complete dependency set, Hexana invokes a composition
 
 Hexana detects which is on `PATH` and adapts. If neither is installed, the Run flow stops with an actionable install hint. If both are installed, `wasm-tools` wins.
 
-The composition produces a **single self-contained component** in a temporary directory, which Wasmtime then executes. See [`run-support.md`](run-support.md) for the full run flow.
+The composition produces a **single self-contained component** in a temporary directory, which the chosen runtime then executes. See [`run-support.md`](run-support.md) for the full run flow.
 
-## Limitations in 0.0.2
+## Limitations in 0.1.0
 
 - **No interface-level export/import drill-down UI** — the Exports and Imports tabs list component-level entities by name, but there is no IDE-style "go to definition" jumping between a component's import and the corresponding export in a sibling component.
 - **No WIT support** — `.wit` files have no language support in the VS Code extension (the JetBrains plugin has full WIT language support, see [`../jetbrains/wit-language.md`](../jetbrains/wit-language.md)).
 - **No component-instance edit** — read-only inspection only.
 - **No interface-version conflict reporting** — if two dependencies require different `@semver` versions of the same interface, Hexana picks one and proceeds; you may want to verify the choice manually.
+- **Debugging across component boundaries** is Wasmtime-only; WAMR's debugger does not yet surface nested-module symbols.
 
 ## See also
 

--- a/docs/vscode/features.md
+++ b/docs/vscode/features.md
@@ -1,18 +1,18 @@
 ---
-title: Hexana for VS Code — Feature Reference (0.0.2)
+title: Hexana for VS Code — Feature Reference (0.1.0)
 description: Complete capability reference for the Hexana VS Code extension.
-version: "0.0.2"
+version: "0.1.0"
 ---
 
 # Hexana for VS Code — Feature Reference
 
-This page enumerates every user-visible capability Hexana 0.0.2 ships for VS Code. For per-tab details on the analysis panels, see [`analysis-tabs.md`](analysis-tabs.md). For per-release changes, see [`changelog.md`](changelog.md).
+This page enumerates every user-visible capability Hexana 0.1.0 ships for VS Code. For per-tab details on the analysis panels, see [`analysis-tabs.md`](analysis-tabs.md). For per-release changes, see [`changelog.md`](changelog.md).
 
 ## Custom binary editor
 
 Hexana registers a `CustomReadonlyEditorProvider` (`hexana.wasmEditor`) for files matching `*.wasm`. When you open a `.wasm`, VS Code uses this editor by default — `workbench.editorAssociations` is set to `{"*.wasm": "hexana.wasmEditor"}` automatically on install.
 
-The editor is **read-only** in 0.0.2. Inspection and run; no in-place editing.
+The editor is **read-only** in 0.1.0. Inspection and run; no in-place editing.
 
 ### Automatic binary kind detection
 
@@ -57,12 +57,32 @@ Up to 11 tabs inside the same editor, surfaced by binary kind. All tables are **
 
 ## Run support
 
-A **Run** button in the editor toolbar, present when Wasmtime is discoverable.
+A **Run** button (and, since 0.1.0, a separate **Debug** button) in the editor toolbar, present when at least one runtime is discoverable.
 
-- **Core modules**: pick an export, supply arguments, Hexana invokes Wasmtime in a VS Code terminal with auto-generated import stubs and `--preload` flags for data segments.
-- **Component Model binaries**: Hexana resolves imports by scanning workspace directories for matching `.wasm` files (transitively), composes the result through `wasm-tools compose` or `wac plug`, then invokes Wasmtime on the composed component.
+- **Runtime picker** — Wasmtime, WAMR, or GraalVM. Unavailable runtimes are greyed out with a tooltip explaining why.
+- **Core modules**: pick an export, the runtime, and supply arguments. Hexana invokes the chosen runtime in a VS Code terminal with auto-generated import stubs and the runtime's equivalent of `--preload` for data segments.
+- **Component Model binaries**: Hexana resolves imports by scanning workspace directories for matching `.wasm` files (transitively), composes the result through `wasm-tools compose` or `wac plug`, then invokes the chosen runtime on the composed component.
 
 See [`run-support.md`](run-support.md) for the full reference.
+
+## Debugging (experimental, 0.1.0+)
+
+A **Debug** button alongside Run launches the module under `lldb` for **Wasmtime** or **WAMR** runtimes (not yet GraalVM). Requires LLVM 22.1 or newer.
+
+- Set breakpoints in source files associated with the module (PC ↔ source mapping via DWARF).
+- Step over, into, out; continue past hit breakpoints.
+- Inspect local variables for compilers that emit DWARF with usable location expressions (Rust, C/C++, Emscripten with `-g`).
+- Component Model nested-module breakpoints are supported on Wasmtime.
+
+See [`run-support.md#debugging-experimental-010`](run-support.md) for the full reference and known limitations.
+
+## MCP server (downloaded on demand, 0.1.0+)
+
+Hexana 0.1.0 ships an integration with VS Code's **Model Context Protocol server registration API**: AI tooling (Claude Desktop, Claude Code, Codex, Cursor's agent mode, Continue) can connect to the Hexana MCP server to inspect the currently open WASM file.
+
+- **First-run download.** On first MCP use, Hexana downloads the standalone MCP server ZIP from the corresponding GitHub release and extracts it to `globalStorage`. Subsequent launches reuse the cached install. Stale download locks are detected and recovered automatically.
+- **`Hexana: Reinstall MCP Server` command** (Command Palette) — re-runs the download to recover from a corrupted install or to re-pull after a Hexana update.
+- **Java requirement.** The MCP server runs on Java 21+. Hexana looks at `JAVA_HOME`, `PATH`, and the `hexana.mcp.javaHome` setting; if no suitable JDK is found, MCP fails to start with an actionable error and Run / Debug are unaffected.
 
 ## Component Model support
 
@@ -74,12 +94,13 @@ See [`component-model.md`](component-model.md).
 
 ## Settings
 
-Two settings under **Settings → Extensions → Hexana**:
+Three settings under **Settings → Extensions → Hexana**:
 
 | Setting | Default | Effect |
 |---|---|---|
 | `hexana.enableStatistics` | `true` | Toggle anonymous usage statistics collection. When `false`, no analytics events are sent regardless of the global VS Code telemetry setting. |
 | `hexana.wasmtimePath` | `""` | Override the Wasmtime executable path. Empty = use whatever is on `PATH`. |
+| `hexana.mcp.javaHome` | `""` | Override the JDK used to launch the on-demand MCP server. Empty = use `JAVA_HOME` / `PATH`. JDK 21+ required for MCP. |
 
 See [`settings.md`](settings.md).
 
@@ -108,17 +129,14 @@ Drag the divider between the hex viewer and the analysis panel to adjust the spl
 
 ## What this version does not do (yet)
 
-Compared to the JetBrains IntelliJ plugin, the 0.0.2 VS Code extension does **not** ship:
+Compared to the JetBrains IntelliJ plugin, the 0.1.0 VS Code extension does **not** ship:
 
 - WIT language support (parser, inspections, completion, navigation).
 - Editable WAT view.
-- MCP server with 17 tools.
 - Java-side completion / inspections for GraalWasm or Chicory.
 - JS / TS-side type inference for `WebAssembly.instantiate`.
-- Debugger.
-- DWARF-based source mapping.
-- Run on WAMR or GraalVM (Wasmtime only in 0.0.2).
-- Goto Symbol contribution.
+- GraalVM debug (debug works on Wasmtime + WAMR only).
+- Goto Symbol contribution scoped to `.wit` declarations and `.wasm` exports.
 
 These are tracked for future versions; some are JetBrains-only by design (where they depend on IntelliJ Platform APIs without a VS Code equivalent).
 

--- a/docs/vscode/getting-started.md
+++ b/docs/vscode/getting-started.md
@@ -1,7 +1,7 @@
 ---
-title: Getting Started with Hexana for VS Code (0.0.2)
+title: Getting Started with Hexana for VS Code (0.1.0)
 description: How to install the Hexana VS Code extension, open a WebAssembly file, and find the main views.
-version: "0.0.2"
+version: "0.1.0"
 ---
 
 # Getting Started with Hexana for VS Code
@@ -27,7 +27,7 @@ The extension activates on `onStartupFinished`, so it is ready as soon as you la
 
 ### From a `.vsix` file (manual)
 
-1. Download `hexana-wasm-0.0.2.vsix` from the GitHub release.
+1. Download `hexana-wasm-0.1.0.vsix` from the GitHub release.
 2. In VS Code, run **Extensions: Install from VSIX…** from the command palette (`Cmd/Ctrl+Shift+P`).
 3. Pick the downloaded file.
 
@@ -51,7 +51,7 @@ Hexana replaces the default editor with a single panel split into three regions:
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  Editor Toolbar                                              │
-│  · file path · binary kind badge · file size · Run button     │
+│  · file path · binary kind badge · file size · Run · Debug    │
 ├─────────────────────────────────┬────────────────────────────┤
 │  Hex Viewer                     │   Analysis Tabs            │
 │  · virtual-scrolling hex dump   │   · Summary · Exports …    │
@@ -70,8 +70,9 @@ The vertical divider between the hex viewer and the analysis panel is **resizabl
 
 - **File path** — full workspace-relative path.
 - **Binary kind badge** — `core`, `component`, or `wasm` (generic).
-- **File size** — in bytes plus a human-readable form.
-- **Run button** — present when Wasmtime is available; clicking it opens the run dialog (see [`run-support.md`](run-support.md)).
+- **File size** — in bytes plus a human-readable form (hover for a per-section breakdown; click to open the **Top** tab).
+- **Run button** — present when at least one runtime (Wasmtime / WAMR / GraalVM) is available; clicking it opens the run dialog with a runtime picker (see [`run-support.md`](run-support.md)).
+- **Debug button** — present when a debug-capable runtime (Wasmtime or WAMR) and LLVM 22.1+ are available; opens the same dialog but launches under `lldb` (experimental).
 
 ### Hex viewer
 
@@ -90,17 +91,20 @@ When you select bytes in the hex viewer, the status bar shows the current byte r
 
 ## How do I run a `.wasm` file?
 
-If you have **Wasmtime** installed, click **Run** in the editor toolbar.
+If you have **Wasmtime**, **WAMR**, or **GraalVM** installed, click **Run** in the editor toolbar.
 
-1. Pick an export (for core modules) — or let Hexana resolve the entry point (for components).
-2. Provide program arguments in the dialog.
-3. The extension opens a terminal and invokes Wasmtime with the right flags.
+1. Pick the **runtime** (Wasmtime / WAMR / GraalVM).
+2. Pick an export (for core modules) — or let Hexana resolve the entry point (for components).
+3. Provide program arguments in the dialog.
+4. The extension opens a terminal and invokes the runtime with the right flags.
 
-If Wasmtime is not on `PATH`, set the path in **Settings → Hexana → Wasmtime Path** (`hexana.wasmtimePath`). See [`run-support.md`](run-support.md) for the full run reference, including Component Model composition with `wasm-tools` or `wac`.
+If Wasmtime is not on `PATH`, set the path in **Settings → Hexana → Wasmtime Path** (`hexana.wasmtimePath`). WAMR and GraalVM are picked up from `PATH` and common install locations.
+
+To **debug** instead of just run, click **Debug** — supported on Wasmtime and WAMR (LLVM 22.1+ required). See [`run-support.md`](run-support.md) for the full reference, including Component Model composition with `wasm-tools` or `wac`.
 
 ## What about WAT files?
 
-Hexana registers the `wat` language association for `.wat` files in 0.0.2 — VS Code gives them a language identifier so other extensions (WebAssembly syntax-highlighting bundles, e.g.) can target them. Hexana itself does **not** open `.wat` in a custom editor in 0.0.2; that surface is JetBrains-IDE-only today.
+Hexana registers the `wat` language association for `.wat` files in 0.1.0 — VS Code gives them a language identifier so other extensions (WebAssembly syntax-highlighting bundles, e.g.) can target them. Hexana itself does **not** open `.wat` in a custom editor in 0.1.0; that surface is JetBrains-IDE-only today.
 
 The **WAT tab** inside the `.wasm` editor *is* available — Hexana renders the WAT representation of the loaded binary in a native VS Code editor tab on demand. See [`analysis-tabs.md#wat`](analysis-tabs.md).
 

--- a/docs/vscode/index.md
+++ b/docs/vscode/index.md
@@ -1,14 +1,15 @@
 ---
-title: Hexana VS Code Extension — Documentation (0.0.2)
-description: User and contributor documentation for the Hexana VS Code extension, version 0.0.2.
-version: "0.0.2"
+title: Hexana VS Code Extension — Documentation (0.1.0)
+description: User and contributor documentation for the Hexana VS Code extension, version 0.1.0 (released 2026-05-20).
+version: "0.1.0"
+released: 2026-05-20
 audience: [users]
-source-branch: release/vscode-0.0.2
+source-branch: release/vscode-0.1.0
 ---
 
 # Hexana — VS Code Extension Documentation
 
-**Hexana** is a Visual Studio Code extension by JetBrains for inspecting WebAssembly binaries. Open any `.wasm` file and Hexana replaces the default editor with a Compose-for-Web webview: a virtual-scrolling hex viewer alongside up to **11 structural-analysis tabs** (Summary, Exports, Imports, Functions, Data, Custom, Top, Monos, Garbage, Modules, WAT). Run modules directly through Wasmtime. Resolve Component Model dependencies automatically. Drill into nested modules. This documentation set describes **release 0.0.2** sourced from branch `release/vscode-0.0.2`.
+**Hexana** is a Visual Studio Code extension by JetBrains for inspecting and running WebAssembly binaries. Open any `.wasm` file and Hexana replaces the default editor with a Compose-for-Web webview: a virtual-scrolling hex viewer alongside up to **11 structural-analysis tabs** (Summary, Exports, Imports, Functions, Data, Custom, Top, Monos, Garbage, Modules, WAT). Run modules through **Wasmtime**, **WAMR**, or **GraalVM**, **debug** them (experimental, LLVM 22.1+), resolve Component Model dependencies automatically, and drive analysis from an AI tool over the on-demand-downloaded **MCP server**. This documentation set describes **release 0.1.0** (2026-05-20) sourced from branch `release/vscode-0.1.0`.
 
 > Looking for the IntelliJ Platform plugin? See the [JetBrains IDEs section](../jetbrains/index.md). The VS Code and JetBrains products share the same WASM parser core but differ in language-support depth, run integrations, and target audience.
 
@@ -19,30 +20,32 @@ source-branch: release/vscode-0.0.2
 | [`getting-started.md`](getting-started.md) | Users | Install the extension, open a `.wasm` file, find the main panels. |
 | [`features.md`](features.md) | Users | Complete capability reference. |
 | [`analysis-tabs.md`](analysis-tabs.md) | Users | Per-tab reference for all 11 analysis panels. |
-| [`run-support.md`](run-support.md) | Users | Run Core Wasm and Component Model binaries through Wasmtime, including composition with `wasm-tools` / `wac`. |
+| [`run-support.md`](run-support.md) | Users | Run Core Wasm and Component Model binaries through Wasmtime, WAMR, or GraalVM, including composition with `wasm-tools` / `wac` and the experimental debug path. |
 | [`component-model.md`](component-model.md) | Users | Component Model support — dependency resolution and nested-module navigation. |
-| [`settings.md`](settings.md) | Users | The two VS Code settings Hexana contributes. |
+| [`settings.md`](settings.md) | Users | VS Code settings Hexana contributes (`hexana.wasmtimePath`, `hexana.enableStatistics`, `hexana.mcp.javaHome`). |
 | [`troubleshooting.md`](troubleshooting.md) | Users | Common failure modes and resolutions. |
-| [`changelog.md`](changelog.md) | All | Release notes. |
+| [`changelog.md`](changelog.md) | All | Release notes, currently pinned at 0.1.0. |
 
 ## Version and compatibility
 
-- **Extension version**: 0.0.2 (marked `preview` on the marketplace).
-- **VS Code requirement**: `^1.85.0` (December 2023 and newer).
+- **Extension version**: 0.1.0 (marked `preview` on the marketplace).
+- **VS Code requirement**: `^1.102.0` — required for the MCP-server registration API used by the on-demand MCP integration. Older 0.0.x releases ran on 1.85+.
+- **Optional Java**: 21 or newer for the MCP server. The server is downloaded on demand on first MCP use; set `hexana.mcp.javaHome` to point at a specific JDK if `JAVA_HOME` / `PATH` do not surface one.
+- **Optional LLVM**: 22.1 or newer for the experimental debug path (Wasmtime + WAMR, `lldb` under the hood).
 - **Distribution**: Visual Studio Marketplace (`marketplace.visualstudio.com/items?itemName=JetBrains.hexana-wasm`) and Open VSX (`open-vsx.org`).
 - **Companion**: a JetBrains IntelliJ plugin, documented [here](../jetbrains/index.md).
 
 ## Supported editors
 
-The extension targets the VS Code Custom Editor API and Compose-for-Web webviews. It works in:
+The extension targets the VS Code Custom Editor API, Webview API, and MCP-server-registration API. It works in:
 
-- **Visual Studio Code** 1.85+
+- **Visual Studio Code** 1.102+
 - **VS Code Insiders**
-- **Cursor** (which is a fork of VS Code)
+- **Cursor** (a fork of VS Code) — provided it exposes the MCP-server-registration API at the 1.102 baseline
 - **Code OSS / VSCodium** when installed from Open VSX
-- **Windsurf**, **Continue.dev**, and other VS Code-based editors that respect the standard extension API
+- **Windsurf**, **Continue.dev**, and other VS Code-based editors that respect the standard extension API at the 1.102 baseline
 
-Some features that depend on VS Code's terminal or filesystem providers may behave differently across forks; report fork-specific issues at the tracker.
+Some features that depend on VS Code's terminal, filesystem, or MCP providers may behave differently across forks; report fork-specific issues at the tracker.
 
 ## How to read this set
 
@@ -53,4 +56,4 @@ Some features that depend on VS Code's terminal or filesystem providers may beha
 
 ## Source of truth
 
-This documentation set describes the **0.0.2** preview release. For unreleased work, see the commit history on `master` after the `release/vscode-0.0.2` tag.
+This documentation set describes the **0.1.0** preview release. For unreleased work, see the commit history on `master` after `release/vscode-0.1.0`.

--- a/docs/vscode/run-support.md
+++ b/docs/vscode/run-support.md
@@ -1,34 +1,39 @@
 ---
-title: Running WebAssembly from Hexana for VS Code (0.0.2)
-description: How to run .wasm modules through Wasmtime — core modules with auto-generated import stubs and Component Model binaries with dependency composition.
-version: "0.0.2"
+title: Running and Debugging WebAssembly from Hexana for VS Code (0.1.0)
+description: How to run and debug .wasm modules through Wasmtime, WAMR, or GraalVM — core modules with auto-generated import stubs and Component Model binaries with dependency composition.
+version: "0.1.0"
 ---
 
-# Running WebAssembly from Hexana for VS Code
+# Running and Debugging WebAssembly from Hexana for VS Code
 
-Hexana 0.0.2 ships a Run button in the editor toolbar that invokes **Wasmtime** in a VS Code terminal. Both core WebAssembly modules and Component Model binaries are supported, with different orchestration for each.
+Hexana 0.1.0 ships **Run** and **Debug** buttons in the editor toolbar. You can invoke a module through one of three runtimes — **Wasmtime**, **WAMR**, or **GraalVM** — and (experimental) attach an `lldb`-backed debugger when running on Wasmtime or WAMR. Both core WebAssembly modules and Component Model binaries are supported, with different orchestration for each.
 
 ## Requirements
 
 | Tool | Required for | Install |
 |---|---|---|
-| **[wasmtime](https://wasmtime.dev/)** | All run scenarios | `curl https://wasmtime.dev/install.sh -sSf \| bash`, or via your package manager. |
+| **[wasmtime](https://wasmtime.dev/)** | Wasmtime runtime + Wasmtime debug | `curl https://wasmtime.dev/install.sh -sSf \| bash`, or via your package manager. |
+| **[WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)** | WAMR runtime + WAMR debug | Build from source or grab a release binary. |
+| **[GraalVM](https://www.graalvm.org/) + GraalWasm** | GraalVM runtime | Install GraalVM and the GraalWasm component; or let Hexana auto-detect. |
 | **[wasm-tools](https://github.com/bytecodealliance/wasm-tools)** | Component Model composition (preferred) | `cargo install wasm-tools`. |
 | **[wac](https://github.com/bytecodealliance/wac)** | Component Model composition (alternative) | `cargo install wac-cli`. |
+| **LLVM 22.1+** (for debug only) | Wasmtime or WAMR debugging | Required because Hexana uses `lldb` 22.1+ wire-protocol features. |
 
-Wasmtime must be on `PATH`, or you must set `hexana.wasmtimePath` in your VS Code settings. `wasm-tools` / `wac` must be on `PATH` only when running component-model binaries with unresolved imports.
+At least one runtime must be on `PATH` (or pointed at via the corresponding setting, e.g. `hexana.wasmtimePath`). `wasm-tools` / `wac` must be on `PATH` only when running component-model binaries with unresolved imports.
 
 ## Core WebAssembly modules
 
 ### How the Run flow works
 
 1. Click **Run** in the editor toolbar of an open `.wasm`.
-2. A dialog opens listing all exported functions. Pick one as the entry point.
+2. A dialog opens listing all exported functions and a **runtime picker** (Wasmtime / WAMR / GraalVM). Pick an entry point and the runtime.
 3. Optionally supply program arguments. Hexana parses the argument string using a shell-aware splitter (quoted strings are preserved as single arguments).
 4. Hexana checks for unresolved imports:
-   - **All imports resolved**: invokes Wasmtime directly.
-   - **Unresolved imports**: Hexana generates **import stubs** — functions that satisfy the import signatures and do nothing (or trap, depending on the kind) — and supplies them via Wasmtime's `--preload` mechanism.
-5. A VS Code terminal opens with the Wasmtime command line, runs the export, and shows output.
+   - **All imports resolved**: invokes the chosen runtime directly.
+   - **Unresolved imports**: Hexana generates **import stubs** — functions that satisfy the import signatures and do nothing (or trap, depending on the kind) — and supplies them via the runtime's preload / linking mechanism.
+5. A VS Code terminal opens with the runtime's command line, runs the export, and shows output.
+
+The Run dialog is always shown so you can confirm runtime, export, and arguments before launch. (Earlier 0.0.x builds sometimes auto-dismissed the dialog.)
 
 ### Generated import stubs
 
@@ -45,7 +50,7 @@ This is **most useful for inspection runs** — confirm that a function is calla
 3. **Dependency resolution** (see [`component-model.md`](component-model.md) for the full algorithm) walks every `.wasm` in the workspace, identifies components that export the interfaces the target imports, and chains them transitively.
 4. If all imports are resolved through workspace components:
    - **Composition** runs `wasm-tools compose` (or `wac plug` if `wasm-tools` is unavailable) to produce a single self-contained component.
-   - **Invocation** runs Wasmtime on the composed component.
+   - **Invocation** runs the chosen runtime on the composed component.
 5. If imports remain unresolved, Hexana falls back to import-stub generation (same as core modules).
 
 ### Composition tool selection
@@ -59,32 +64,47 @@ You can install only one — Hexana adapts. If neither is installed and your bin
 
 ## Run dialog
 
-The dialog has three sections:
+The dialog has four sections:
 
+- **Runtime** — dropdown of detected runtimes (Wasmtime / WAMR / GraalVM). Unavailable runtimes are greyed out with a tooltip explaining why.
 - **Export** — dropdown of all exported functions (core modules) or the component's primary entry interface (components).
 - **Arguments** — free-text field. Shell-style quoting is supported via Hexana's `splitShellArgs` Kotlin/JS utility. Backslash escapes work for spaces; single and double quotes group arguments.
-- **Environment** (implicit) — Hexana passes through your current shell environment to Wasmtime.
+- **Environment** (implicit) — Hexana passes through your current shell environment to the chosen runtime.
 
-Click **Run** to start; the dialog closes and a terminal opens with the live invocation.
+Click **Run** (or **Debug** to launch under the debugger — see below) to start; the dialog closes and a terminal opens with the live invocation.
+
+## Debugging (experimental, 0.1.0+)
+
+Click **Debug** instead of **Run** to launch the module under `lldb`. Supported on **Wasmtime** and **WAMR**; not yet on GraalVM.
+
+- **Breakpoints** — set them in source files associated with the module (Hexana maps PCs to source via DWARF). Breakpoints inside nested modules of a Component Model binary are supported on Wasmtime only.
+- **Stepping** — step over, into, and out; continue past hit breakpoints.
+- **Variables** — local-variable inspection works for compilers that emit DWARF with reasonable location expressions (Rust, C/C++, Emscripten with `-g`).
+- **Requirements** — LLVM 22.1 or newer must be on `PATH`, and the WASM binary must be compiled with debug info that `lldb` can interpret.
+
+Known limitations:
+
+- GraalVM debug is not yet wired.
+- Some compilers' DWARF (especially aggressive-CGU Rust builds) produces source paths that need fuzzy matching; if a breakpoint does not bind, check the **Debug Console** for the path Hexana tried to resolve and file a tracker issue.
 
 ## Terminal output
 
-Each run gets its own VS Code terminal named after the run target (export name or component path). Stderr and stdout are shown verbatim — Hexana does not parse or filter Wasmtime's output. Use the terminal's normal search and copy.
+Each run gets its own VS Code terminal named after the run target (export name or component path). Stderr and stdout are shown verbatim — Hexana does not parse or filter the runtime's output. Use the terminal's normal search and copy.
 
-Killing the terminal kills the Wasmtime process.
+Killing the terminal kills the runtime process.
 
 ## Configuration
 
 | Setting | Default | Effect |
 |---|---|---|
 | `hexana.wasmtimePath` | `""` (use PATH) | Absolute path to a specific Wasmtime executable. Useful for testing pre-release builds or pinning to a vendored copy. |
+| `hexana.mcp.javaHome` | `""` (use JAVA_HOME / PATH) | Absolute path to a JDK 21+ home directory. Only relevant when the MCP server is enabled (used by AI tooling); not required for Run / Debug. |
 
-There is no setting to override `wasm-tools` or `wac` paths in 0.0.2 — both must be on `PATH`.
+There is no setting to override `wasm-tools`, `wac`, WAMR, or GraalVM paths in 0.1.0 — all must be on `PATH` (GraalVM is auto-detected from common install locations as well).
 
 ## What this version does not do
 
-- **No debugging.** The JetBrains plugin supports experimental debugging since 0.9 (Wasmtime + WAMR + LLDB). The VS Code extension does not in 0.0.2.
-- **No WAMR or GraalVM runtimes.** Wasmtime only.
+- **GraalVM debug is not yet wired.** Debug works on Wasmtime and WAMR only.
 - **No proposal-flag selection UI.** Hexana detects which proposals the binary uses and passes the appropriate `--wasm-features` flags automatically, but there is no UI to override.
 - **No run-configuration persistence.** Each Run is ad-hoc; arguments are not saved between runs. The dialog remembers the last set within the editor session but discards them on close.
 - **No host-function injection.** You cannot supply your own implementations for unresolved imports; you get auto-generated stubs or nothing.

--- a/docs/vscode/settings.md
+++ b/docs/vscode/settings.md
@@ -1,12 +1,12 @@
 ---
-title: Hexana for VS Code — Settings (0.0.2)
-description: The two VS Code settings the Hexana extension contributes, plus the telemetry consent model.
-version: "0.0.2"
+title: Hexana for VS Code — Settings (0.1.0)
+description: The VS Code settings the Hexana extension contributes, plus the telemetry consent model.
+version: "0.1.0"
 ---
 
 # Settings
 
-Hexana for VS Code 0.0.2 contributes two settings, both under `Settings → Extensions → Hexana` (`hexana.*` in `settings.json`).
+Hexana for VS Code 0.1.0 contributes three settings, all under `Settings → Extensions → Hexana` (`hexana.*` in `settings.json`).
 
 ## `hexana.enableStatistics`
 
@@ -34,7 +34,26 @@ Absolute path to the Wasmtime executable. Use this when:
 
 Hexana does not validate the path at save time — if the path is wrong, you'll see the failure when you next click **Run**.
 
-There is no analogous setting for `wasm-tools` or `wac` (used in Component Model composition); both must be on `PATH`.
+There are no analogous settings for `wasm-tools`, `wac`, WAMR, or GraalVM in 0.1.0 — all must be on `PATH` (GraalVM is auto-detected from common install locations as well).
+
+## `hexana.mcp.javaHome`
+
+| Field | Value |
+|---|---|
+| **Type** | `string` |
+| **Default** | `""` (empty — Hexana looks at `JAVA_HOME` and the `PATH` `java` binary) |
+
+Absolute path to a Java 21+ home directory. Used to start the **Hexana MCP server**, which is downloaded on demand from GitHub Releases the first time an MCP client requests it.
+
+Use this setting when:
+
+- `JAVA_HOME` points at a JDK older than 21.
+- You want to pin the MCP server to a specific JDK distribution.
+- There is no `java` on `PATH` (e.g. headless containers).
+
+If unset and no suitable JDK is found, the MCP server fails to start with an actionable error in the **Output → Hexana MCP** channel; Run / Debug are not affected.
+
+You can also force a fresh download via the **Hexana: Reinstall MCP Server** command in the Command Palette.
 
 ## Telemetry — the full consent model
 

--- a/docs/vscode/troubleshooting.md
+++ b/docs/vscode/troubleshooting.md
@@ -1,12 +1,12 @@
 ---
-title: Hexana for VS Code — Troubleshooting (0.0.2)
+title: Hexana for VS Code — Troubleshooting (0.1.0)
 description: Common issues users hit with the Hexana VS Code extension and how to resolve them.
-version: "0.0.2"
+version: "0.1.0"
 ---
 
 # Troubleshooting
 
-Common issues users hit with Hexana for VS Code 0.0.2 and how to resolve them.
+Common issues users hit with Hexana for VS Code 0.1.0 and how to resolve them.
 
 ## A .wasm file opens in the default editor, not Hexana
 
@@ -44,12 +44,42 @@ The extension host reads the file via `vscode.workspace.fs`. Failures usually me
 
 ## The Run button is greyed out
 
-Wasmtime is not discoverable. Either:
+No supported runtime (Wasmtime / WAMR / GraalVM) is discoverable. Either:
 
 - Install Wasmtime: `curl https://wasmtime.dev/install.sh -sSf | bash`.
+- Install WAMR — see [WAMR's README](https://github.com/bytecodealliance/wasm-micro-runtime).
+- Install GraalVM with GraalWasm — Hexana auto-detects common install locations.
 - Or set `hexana.wasmtimePath` to an absolute path in your VS Code settings.
 
 After fixing, reload the window.
+
+## The Debug button is greyed out
+
+Debug requires a debug-capable runtime (Wasmtime or WAMR) **and** LLVM 22.1 or newer on `PATH`.
+
+- Check `lldb --version`. If it is older than 22.1, install a newer LLVM toolchain.
+- Confirm Wasmtime or WAMR is on `PATH` (GraalVM debug is not yet wired in 0.1.0).
+- Confirm the binary you opened was compiled with debug info (`-g`); a stripped binary will let the debugger attach but produce no usable source mapping.
+
+## A breakpoint does not bind during Debug
+
+Hexana maps PCs to source files via DWARF. Common reasons a breakpoint does not bind:
+
+- The binary was compiled without `-g`, or with `-Cstrip=debuginfo` (Rust) / equivalent.
+- The source path stored in DWARF differs from what's open in VS Code. Aggressive-CGU Rust builds tag source files with a CGU suffix; Hexana applies fuzzy matching but does not always win.
+- The line you set the breakpoint on lies inside an inlined function whose DWARF was elided.
+
+Open **View → Output → Hexana** and look for `[dwarf-debug]` lines to see what path Hexana tried to resolve.
+
+## "Hexana MCP server: download failed" / MCP integration broken
+
+The MCP server is downloaded on demand from GitHub Releases. If it fails:
+
+1. Check VS Code's **Output → Hexana MCP** channel for the underlying error (network, disk, JDK).
+2. Confirm a Java 21+ JDK is discoverable — through `JAVA_HOME`, `PATH`, or the `hexana.mcp.javaHome` setting.
+3. Run **Hexana: Reinstall MCP Server** from the Command Palette to force a fresh download.
+4. If a previous download appears stuck (no progress, but the download lock file is present), Hexana detects and recovers stale locks automatically; reload the window if that fails.
+5. Disk corruption or a partial extraction sometimes leaves a broken cache — running the Reinstall command from step 3 deletes and re-fetches.
 
 ## Run fails on a component binary with "unable to compose"
 
@@ -76,7 +106,7 @@ Hexana scans the entire workspace and matches by fully-qualified interface name 
 Workarounds:
 
 - Move the unwanted dependency out of the workspace.
-- Add `.vscode/settings.json` to exclude the file from Hexana's search — **not yet supported in 0.0.2**; track on the roadmap.
+- Add `.vscode/settings.json` to exclude the file from Hexana's search — **not yet supported in 0.1.0**; track on the roadmap.
 - Vendor the correct dependency under a unique workspace path.
 
 ## Run terminal closes immediately or shows no output

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ nav:
       - JavaScript & TypeScript: jetbrains/js-integration.md
       - Settings: jetbrains/settings.md
       - Troubleshooting: jetbrains/troubleshooting.md
-      - Changelog 0.9: jetbrains/changelog-0.9.md
+      - Changelog 0.9.x: jetbrains/changelog-0.9.md
 
   - VS Code:
       - Overview: vscode/index.md


### PR DESCRIPTION
…ease/vscode-0.1.0)

JetBrains side (changelog-0.9.md, jetbrains/index.md):
- Add 0.9.1 (2026-05-20) section to changelog-0.9.md: Goto Symbol / Search Everywhere now surfaces .wit declarations and .wasm exports; build toolchain bumped to Java 21; IntelliJ Driver dep updated.
- Bump index.md to 0.9.x line, current 0.9.1, source commit 9a615b34.

VS Code side (vscode/*.md, llms.txt, root index, mkdocs.yml):
- Replace 0.0.2-pinned framing with 0.1.0 (release/vscode-0.1.0).
- Document the three big additions: experimental lldb-backed debugging (Wasmtime + WAMR, LLVM 22.1+), runtime picker for Run/Debug (Wasmtime / WAMR / GraalVM), and on-demand-downloaded MCP server with the Reinstall command and hexana.mcp.javaHome setting.
- Raise VS Code minimum to 1.102+; note 0.0.x still ran on 1.85+.
- Correct cross-product comparisons in docs/index.md and llms.txt ("Run on WAMR or GraalVM" and "MCP server" are no longer JetBrains-only; "Debugger" is now both, experimentally).
- Update troubleshooting for the new Debug / MCP failure modes.