### PR TITLE
[doc] Document VS Code 0.4.0: in-place byte editing and Node.js/Chrome debugging

### DIFF
--- a/docs/vscode/changelog.md
+++ b/docs/vscode/changelog.md
@@ -1,12 +1,21 @@
 ---
 title: Hexana for VS Code — Release Notes
 description: Release notes for the Hexana VS Code extension.
-version: "0.3.0"
+version: "0.4.0"
 ---
 
 # Release Notes — Hexana for VS Code
 
 This page tracks releases of the VS Code extension.
+
+## 0.4.0
+
+Released **2026-06-16**.
+
+### Added
+
+- **In-place byte editing in the hex viewer.** You can now edit individual bytes directly in the hex viewer — select a byte, type a new value — and write the result back to the original file with the **overwrite-file** action. Editing is **overwrite-only: the file size never changes** (you cannot insert or remove bytes). Earlier versions were inspection-only.
+- **Debugging on the Node.js and browser runtimes.** Node.js and the browser — **run-only** since 0.3.0 — are now debuggable. Hexana drives them over the **Chrome DevTools Protocol (CDP)**: Node.js is launched with `--inspect-brk`, Chrome with `--remote-debugging-port`, and Hexana translates DAP ↔ CDP so VS Code's debugger can set breakpoints, step, and inspect state. This complements the existing `lldb`-backed Wasmtime / WAMR debug path (LLVM 22.1+). GraalVM remains run-only.
 
 ## 0.3.0
 
@@ -131,4 +140,4 @@ VS Code forks (Cursor, Code OSS / VSCodium, Windsurf, Continue.dev) are supporte
 ## See also
 
 - [`getting-started.md`](getting-started.md), [`features.md`](features.md), [`run-support.md`](run-support.md), [`settings.md`](settings.md).
-- The JetBrains plugin's [changelog](../jetbrains/changelog-0.10.md).
+- The JetBrains plugin's [changelog](../jetbrains/changelog-0.11.md).

--- a/docs/vscode/features.md
+++ b/docs/vscode/features.md
@@ -1,7 +1,7 @@
 ---
 title: Hexana for VS Code — Feature Reference
 description: Complete capability reference for the Hexana VS Code extension.
-version: "0.3.0"
+version: "0.4.0"
 ---
 
 # Hexana for VS Code — Feature Reference
@@ -12,7 +12,7 @@ This page enumerates every user-visible capability Hexana ships for VS Code. For
 
 Hexana registers a `CustomReadonlyEditorProvider` (`hexana.wasmEditor`) for files matching `*.wasm`. When you open a `.wasm`, VS Code uses this editor by default — `workbench.editorAssociations` is set to `{"*.wasm": "hexana.wasmEditor"}` automatically on install.
 
-The editor is **read-only**. Inspection and run; no in-place editing.
+Since **0.4.0** the hex viewer supports **in-place byte editing**: select a byte, type a new value, and persist the change to the original file with the **overwrite-file** action. Editing is **overwrite-only — the file size never changes** (you cannot insert or delete bytes). Editing the structured WAT view, as in the JetBrains plugin, is not available in VS Code.
 
 ### Automatic binary kind detection
 
@@ -35,6 +35,7 @@ A virtual-scrolling hex dump with:
 - **Keyboard navigation**: arrow keys move the caret; `Shift+Arrow` extends selection.
 - **Text search** (`Cmd/Ctrl+F`): incremental search across the hex dump.
 - **Selection status bar**: shows the current byte range and decoded interpretations.
+- **In-place byte editing (0.4.0)**: overwrite individual bytes and write the result back to the file with the **overwrite-file** action. Overwrite-only — the file size never changes.
 
 The viewer renders through Compose-for-Web inside a VS Code webview — it scales smoothly to large files without DOM-node-per-byte overhead.
 
@@ -81,7 +82,7 @@ Up to 11 tabs inside the same editor, surfaced by binary kind. All tables are **
 
 A **Run** button and a separate **Debug** button in the editor toolbar, present when at least one runtime is discoverable.
 
-- **Runtime picker** — Wasmtime, WAMR, GraalVM, Node.js, or the browser (Node.js and browser added in 0.3.0, run-only). Unavailable runtimes are greyed out with a tooltip explaining why.
+- **Runtime picker** — Wasmtime, WAMR, GraalVM, Node.js, or the browser (Node.js and browser added in 0.3.0; debuggable since 0.4.0). Unavailable runtimes are greyed out with a tooltip explaining why.
 - **Core modules**: pick an export, the runtime, and supply arguments. Hexana invokes the chosen runtime in a VS Code terminal with auto-generated import stubs and the runtime's equivalent of `--preload` for data segments.
 - **Component Model binaries**: Hexana resolves imports by scanning workspace directories for matching `.wasm` files (transitively), composes the result through `wasm-tools compose` or `wac plug`, then invokes the chosen runtime on the composed component.
 
@@ -89,9 +90,14 @@ See [`run-support.md`](run-support.md) for the full reference.
 
 ## Debugging (experimental)
 
-A **Debug** button alongside Run launches the module under `lldb` for **Wasmtime** or **WAMR** runtimes (not GraalVM, Node.js, or the browser — those are run-only in VS Code). Requires LLVM 22.1 or newer.
+A **Debug** button alongside Run launches the module under a debugger. Two backends, by runtime (GraalVM is run-only):
 
-- Set breakpoints in source files associated with the module (PC ↔ source mapping via DWARF).
+- **`lldb`-backed — Wasmtime and WAMR.** Requires LLVM 22.1 or newer; breakpoints map to source via DWARF.
+- **CDP-backed — Node.js and Chrome (0.4.0).** Hexana launches Node.js with `--inspect-brk` or Chrome with `--remote-debugging-port`, connects over the Chrome DevTools Protocol, and translates DAP ↔ CDP.
+
+Across both backends:
+
+- Set breakpoints in source files associated with the module (PC ↔ source mapping via DWARF on the `lldb` path).
 - Step over, into, out; continue past hit breakpoints.
 - Inspect local variables for compilers that emit DWARF with usable location expressions (Rust, C/C++, Emscripten with `-g`).
 - Component Model nested-module breakpoints are supported on Wasmtime.
@@ -157,7 +163,7 @@ Compared to the JetBrains IntelliJ plugin, the VS Code extension does **not** sh
 - Editable WAT view.
 - Java-side completion / inspections for GraalWasm or Chicory.
 - JS / TS-side type inference for `WebAssembly.instantiate`.
-- GraalVM, Node.js, and browser debug (debug works on Wasmtime + WAMR only; Node.js and the browser are run-only).
+- GraalVM debug (GraalVM is run-only). Node.js and browser debug landed in 0.4.0 over CDP; Wasmtime / WAMR debug over `lldb`.
 - Goto Symbol contribution scoped to `.wit` declarations and `.wasm` exports.
 - Decoded JVM artifact views — the three-tab `.class` view and the `.jit` viewer — and the switchable AOT / Cranelift disassembler backend. (Archives `.jar` / `.zip` / `.war` / `.apk` *do* open with a hex + entry list since 0.3.0; nested `.class` entries open in the hex viewer, not the decoded class view.)
 

--- a/docs/vscode/getting-started.md
+++ b/docs/vscode/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Hexana for VS Code
 description: How to install the Hexana VS Code extension, open a WebAssembly file, and find the main views.
-version: "0.2.0"
+version: "0.4.0"
 ---
 
 # Getting Started with Hexana for VS Code
@@ -72,7 +72,7 @@ The vertical divider between the hex viewer and the analysis panel is **resizabl
 - **Binary kind badge** — `core`, `component`, or `wasm` (generic).
 - **File size** — in bytes plus a human-readable form (hover for a per-section breakdown; click to open the **Top** tab).
 - **Run button** — present when at least one runtime (Wasmtime / WAMR / GraalVM) is available; clicking it opens the run dialog with a runtime picker (see [`run-support.md`](run-support.md)).
-- **Debug button** — present when a debug-capable runtime (Wasmtime or WAMR) and LLVM 22.1+ are available; opens the same dialog but launches under `lldb` (experimental).
+- **Debug button** — present when a debug-capable runtime is available; opens the same dialog but launches under a debugger (experimental). Wasmtime and WAMR debug under `lldb` (LLVM 22.1+ required); Node.js and Chrome debug over the Chrome DevTools Protocol since 0.4.0. GraalVM is run-only.
 
 ### Hex viewer
 
@@ -100,7 +100,7 @@ If you have **Wasmtime**, **WAMR**, or **GraalVM** installed, click **Run** in t
 
 If Wasmtime is not on `PATH`, set the path in **Settings → Hexana → Wasmtime Path** (`hexana.wasmtimePath`). WAMR and GraalVM are picked up from `PATH` and common install locations.
 
-To **debug** instead of just run, click **Debug** — supported on Wasmtime and WAMR (LLVM 22.1+ required). See [`run-support.md`](run-support.md) for the full reference, including Component Model composition with `wasm-tools` or `wac`.
+To **debug** instead of just run, click **Debug** — supported on Wasmtime and WAMR via `lldb` (LLVM 22.1+ required), and on Node.js and Chrome via the Chrome DevTools Protocol (0.4.0). GraalVM is run-only. See [`run-support.md`](run-support.md) for the full reference, including Component Model composition with `wasm-tools` or `wac`.
 
 ## What about WAT files?
 

--- a/docs/vscode/index.md
+++ b/docs/vscode/index.md
@@ -1,13 +1,13 @@
 ---
 title: Hexana VS Code Extension — Documentation
 description: User and contributor documentation for the Hexana VS Code extension.
-version: "0.3.0"
+version: "0.4.0"
 audience: [users]
 ---
 
 # Hexana — VS Code Extension Documentation
 
-**Hexana** is a Visual Studio Code extension by JetBrains for inspecting and running WebAssembly binaries — and, since 0.2.0, native binaries (ELF, Mach-O, PE); since 0.3.0, JVM archives (`.jar`, `.zip`, `.war`, `.apk`) as well. Open any `.wasm` file and Hexana replaces the default editor with a Compose-for-Web webview: a virtual-scrolling hex viewer alongside up to **11 structural-analysis tabs** (Summary, Exports, Imports, Functions, Data, Custom, Top, Monos, Garbage, Modules, WAT). Native binaries and archives open with the same hex + structure layout. Run modules through **Wasmtime**, **WAMR**, **GraalVM**, **Node.js**, or the **browser**, **debug** them (experimental, LLVM 22.1+, Wasmtime / WAMR only), resolve Component Model dependencies automatically, and drive analysis from an AI tool over the on-demand-downloaded **MCP server**.
+**Hexana** is a Visual Studio Code extension by JetBrains for inspecting and running WebAssembly binaries — and, since 0.2.0, native binaries (ELF, Mach-O, PE); since 0.3.0, JVM archives (`.jar`, `.zip`, `.war`, `.apk`) as well. Open any `.wasm` file and Hexana replaces the default editor with a Compose-for-Web webview: a virtual-scrolling hex viewer alongside up to **11 structural-analysis tabs** (Summary, Exports, Imports, Functions, Data, Custom, Top, Monos, Garbage, Modules, WAT). Native binaries and archives open with the same hex + structure layout. Since 0.4.0 the hex viewer also supports **in-place byte editing** (overwrite-only — the file size never changes). Run modules through **Wasmtime**, **WAMR**, **GraalVM**, **Node.js**, or the **browser**, **debug** them (experimental) — `lldb`-backed on Wasmtime / WAMR (LLVM 22.1+), and, since 0.4.0, CDP-backed on Node.js and Chrome — resolve Component Model dependencies automatically, and drive analysis from an AI tool over the on-demand-downloaded **MCP server**.
 
 > Looking for the IntelliJ Platform plugin? See the [JetBrains IDEs section](../jetbrains/index.md). The VS Code and JetBrains products share the same WASM parser core but differ in language-support depth, run integrations, and target audience.
 

--- a/docs/vscode/run-support.md
+++ b/docs/vscode/run-support.md
@@ -1,12 +1,12 @@
 ---
 title: Running and Debugging WebAssembly from Hexana for VS Code
 description: How to run and debug .wasm modules through Wasmtime, WAMR, GraalVM, Node.js, or the browser — core modules with auto-generated import stubs and Component Model binaries with dependency composition.
-version: "0.3.0"
+version: "0.4.0"
 ---
 
 # Running and Debugging WebAssembly from Hexana for VS Code
 
-Hexana ships **Run** and **Debug** buttons in the editor toolbar. You can invoke a module through one of five runtimes — **Wasmtime**, **WAMR**, **GraalVM**, **Node.js**, or the **browser** — and (experimental) attach an `lldb`-backed debugger when running on Wasmtime or WAMR. Node.js and the browser were added in 0.3.0 and are **run-only** in VS Code. Both core WebAssembly modules and Component Model binaries are supported, with different orchestration for each.
+Hexana ships **Run** and **Debug** buttons in the editor toolbar. You can invoke a module through one of five runtimes — **Wasmtime**, **WAMR**, **GraalVM**, **Node.js**, or the **browser** — and (experimental) attach a debugger to all of them except GraalVM: an `lldb`-backed debugger on Wasmtime and WAMR, and (since **0.4.0**) a Chrome DevTools Protocol debugger on Node.js and Chrome. Node.js and the browser were added as run targets in 0.3.0. Both core WebAssembly modules and Component Model binaries are supported, with different orchestration for each.
 
 ## Requirements
 
@@ -66,7 +66,7 @@ You can install only one — Hexana adapts. If neither is installed and your bin
 
 The dialog has four sections:
 
-- **Runtime** — dropdown of detected runtimes (Wasmtime / WAMR / GraalVM / Node.js / browser). Unavailable runtimes are greyed out with a tooltip explaining why. Node.js and the browser are run-only.
+- **Runtime** — dropdown of detected runtimes (Wasmtime / WAMR / GraalVM / Node.js / browser). Unavailable runtimes are greyed out with a tooltip explaining why. All runtimes except GraalVM can also be debugged (see [Debugging](#debugging-experimental)).
 - **Export** — dropdown of all exported functions (core modules) or the component's primary entry interface (components).
 - **Arguments** — free-text field. Shell-style quoting is supported via Hexana's `splitShellArgs` Kotlin/JS utility. Backslash escapes work for spaces; single and double quotes group arguments.
 - **Environment** (implicit) — Hexana passes through your current shell environment to the chosen runtime.
@@ -75,17 +75,27 @@ Click **Run** (or **Debug** to launch under the debugger — see below) to start
 
 ## Debugging (experimental)
 
-Click **Debug** instead of **Run** to launch the module under `lldb`. Supported on **Wasmtime** and **WAMR**; not yet on GraalVM.
+Click **Debug** instead of **Run** to launch the module under a debugger. Hexana has two debug backends, selected by the runtime you pick; **GraalVM is run-only**.
 
+### `lldb`-backed — Wasmtime and WAMR
+
+- **Requirements** — LLVM 22.1 or newer must be on `PATH`, and the WASM binary must be compiled with debug info that `lldb` can interpret.
 - **Breakpoints** — set them in source files associated with the module (Hexana maps PCs to source via DWARF). Breakpoints inside nested modules of a Component Model binary are supported on Wasmtime only.
 - **Stepping** — step over, into, and out; continue past hit breakpoints.
 - **Variables** — local-variable inspection works for compilers that emit DWARF with reasonable location expressions (Rust, C/C++, Emscripten with `-g`).
-- **Requirements** — LLVM 22.1 or newer must be on `PATH`, and the WASM binary must be compiled with debug info that `lldb` can interpret.
+
+### CDP-backed — Node.js and Chrome (0.4.0)
+
+Choosing **Debug** with the Node.js or browser runtime drives the runtime over the **Chrome DevTools Protocol (CDP)** instead of `lldb`:
+
+- Node.js is launched with `--inspect-brk`; Chrome with `--remote-debugging-port`. Hexana connects over a CDP WebSocket and translates DAP ↔ CDP so VS Code's standard debugger UI (breakpoints, stepping, call stack, variables) works against the WASM running in the JS host.
+- Chrome/Chromium is located from common install locations for your platform; install Google Chrome (or a Chromium build) to use the browser path.
+- No LLVM is required for this backend.
 
 Known limitations:
 
-- GraalVM debug is not yet wired.
-- Some compilers' DWARF (especially aggressive-CGU Rust builds) produces source paths that need fuzzy matching; if a breakpoint does not bind, check the **Debug Console** for the path Hexana tried to resolve and file a tracker issue.
+- GraalVM debug is not wired (run-only).
+- Some compilers' DWARF (especially aggressive-CGU Rust builds) produces source paths that need fuzzy matching; if a breakpoint does not bind on the `lldb` path, check the **Debug Console** for the path Hexana tried to resolve and file a tracker issue.
 
 ## Terminal output
 
@@ -104,7 +114,7 @@ There is no setting to override `wasm-tools`, `wac`, WAMR, or GraalVM paths — 
 
 ## What this version does not do
 
-- **GraalVM, Node.js, and browser debug are not wired.** Debug works on Wasmtime and WAMR only; GraalVM, Node.js, and the browser are run-only in VS Code.
+- **GraalVM debug is not wired.** GraalVM is run-only. (Wasmtime / WAMR debug over `lldb`; Node.js / Chrome debug over CDP since 0.4.0.)
 - **No proposal-flag selection UI.** Hexana detects which proposals the binary uses and passes the appropriate `--wasm-features` flags automatically, but there is no UI to override.
 - **No run-configuration persistence.** Each Run is ad-hoc; arguments are not saved between runs. The dialog remembers the last set within the editor session but discards them on close.
 - **No host-function injection.** You cannot supply your own implementations for unresolved imports; you get auto-generated stubs or nothing.


### PR DESCRIPTION
Documents the **VS Code 0.4.0** release. Follows #100 (IntelliJ 0.11.1 + VS Code 0.3.0), which is already merged — this PR is the VS Code 0.4.0 delta only (5 files under `docs/vscode/`).

## 0.4.0 features

- **In-place byte editing in the hex viewer** — overwrite individual bytes and write back via the overwrite-file action. **Overwrite-only: the file size never changes** (no insert/delete).
- **Debugging on the Node.js and browser runtimes** — run-only since 0.3.0, now debuggable over the **Chrome DevTools Protocol** (Node `--inspect-brk`, Chrome `--remote-debugging-port`, DAP↔CDP), alongside the existing `lldb` Wasmtime/WAMR path. GraalVM remains run-only.

## Doc changes

- `changelog.md` — 0.4.0 section; version → 0.4.0; JetBrains cross-link bumped to changelog-0.11.
- `features.md` — hex-viewer byte editing; Debugging split into `lldb` (Wasmtime/WAMR) and CDP (Node.js/Chrome) backends; "does not do" narrowed to GraalVM-only run-only.
- `run-support.md` — intro, runtime note, two-backend Debugging section, limitations.
- `index.md`, `getting-started.md` — byte editing + Node/Chrome debug; version bumps.

## Notes

- 0.4.0 dated **2026-06-16** (the `release/vscode-0.4.0` head); source CHANGELOG had no date — verify before release.
- `hexana.chromePath` is read by the debug adapter but **not** declared in `package.json` contributions, so it's intentionally not documented as a setting (Chrome is auto-discovered).
- Cross-reference anchors verified against Python-Markdown slugify; MkDocs not installed locally for a full `--strict` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)