### PR TITLE
[doc] Document 0.12 (IntelliJ) and 0.5.0 (VS Code) releases

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,8 @@ hide:
 
     Full IntelliJ Platform plugin — multi-tab `.wasm` editor with an editable virtualised WAT view, WAT and WIT language support, MCP server with Hexana tools, Java-side completion for GraalWasm and Chicory, JavaScript / TypeScript type inference for `WebAssembly.instantiate`, run and debug on Wasmtime / WAMR / GraalVM. Experimental ELF / Mach-O / PE binary support, JVM artifact viewers (`.class`, `.jar`, `.war`, `.apk`, `.jit`), and a switchable disassembler backend (bytecode AOT or Cranelift native).
 
-    **Current release**: 0.10
-    Supported IDEs: IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
+    **Current release**: 0.12
+    Supported IDEs: IntelliJ IDEA 2025.2+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
 
     [Read the docs →](jetbrains/index.md)
 

--- a/docs/jetbrains/changelog-0.12.md
+++ b/docs/jetbrains/changelog-0.12.md
@@ -1,0 +1,104 @@
+---
+title: Hexana 0.12 Release Notes
+description: Release notes for Hexana 0.12 — static-library archive inspection (.a/.lib), Component Model diff and WAT view, full Component Model size breakdown, Exports/Imports row affordances with Find Usages, Android DEX support, and ZIP64 archives.
+version: "0.12"
+released: 2026-06-24
+---
+
+# Hexana 0.12 Release Notes
+
+Released **2026-06-24**. No breaking changes from 0.11.1.
+
+0.12 extends Hexana's analysis breadth across three fronts: it opens static-library archives (`.a` and `.lib`) for inspection with per-function disassembly of the extracted object files; it brings Component Model binaries into the existing diff and WAT viewer surfaces that 0.11.1 established for core modules; and it adds per-row affordances to the Exports and Imports tabs (tooltips, copy actions, and an Imports-side Find Usages that lists callers). Android DEX and ZIP64 round out the format coverage.
+
+## Static-library archives
+
+<!-- TODO: screenshot for static-library Members view -->
+
+`.a` (Unix `ar`) and `.lib` (Windows COFF import library) archives now open in Hexana as a structured **Members** list. Each row names the member, reports its detected format (ELF / Mach-O / PE / COFF / short-import), and shows its size. The archive's own bookkeeping entries (symbol tables, long-names table) are hidden from the list.
+
+Clicking a member extracts the object file to the IDE's temp folder and opens it in the matching disassembly view. Because the extracted file lands on disk as a real file, both the Capstone and llvm-objdump disassembly backends are available. The member tab is titled `archive-name/member-name`; when two members share a name, an index is appended to keep the titles distinct.
+
+Archives are detected by their `!<arch>\n` content magic, not by extension, so renaming a file does not confuse detection. Plain MSVC import `.lib` files that do not carry the `!<arch>\n` header are left to their normal handler.
+
+### Per-function disassembly of archive members
+
+Relocatable object files (ELF `.o`, Windows COFF `.obj`/`.o`, Mach-O) lay out function symbols section-relative rather than at virtual addresses. Hexana now resolves each symbol's file offset through its owning section, so the virtualized Capstone view lists each named function individually rather than presenting only the whole `.text` section as a single block. Members whose symbols are stripped still fall back to disassembling code sections whole.
+
+## Component Model diff and WAT view (0.12)
+
+### Comparing Component Model binaries
+
+**Compare WASM With…** (introduced in 0.11.1 for core modules) now accepts Component Model binaries. Comparing two components opens a submodule view listing each component's embedded submodules — core modules and nested components, found recursively — and classifies each as identical, modified, added, or removed. Clicking a changed pair opens a dedicated tab:
+
+- A **core-module pair** reuses the existing Size Impact / Entities / WAT diff from 0.11.1.
+- A **nested-component pair** recurses into the same submodule view.
+
+Submodules are paired by content hash, with positional fallback when hashes do not match.
+
+### WAT (virtualized) tab for Component Model binaries
+
+A Component Model binary's code lives in embedded core modules. The WAT tab now discovers every embedded core module recursively (through nested sub-components) and renders the selected one with the same structured, lazily-parsed virtualized WAT view that core modules use: three-column offset / bytes / mnemonic layout, per-function navigation, and folding. When a component contains more than one core module, a selector switches between them.
+
+This view is also available for in-memory component views, such as a submodule opened from a diff, which previously had no WAT tab.
+
+## Component Model size breakdown (0.12)
+
+The **Top** tab's size profiler now attributes every nested sub-component and embedded core module with its correct byte count, expanding on demand to internal sections and then to functions, recursively. In 0.11.1 and earlier, a composed component reported most of its bytes as a single opaque block because the profiler read only the first nested component section. The fix corrects a coroutine-cancellation bug in the lazy children generator: the generator was inheriting the already-cancelled flag from the tree-build coroutine and silently producing no children.
+
+## Exports and Imports row affordances (0.12)
+
+### Exports tab
+
+Each row in the **Exports** tab gains:
+
+- A **tooltip** showing the full export name (for names truncated by the column width).
+- A **Copy Name** context-menu action.
+- A **Navigate to Function in WAT** action (shown only for function exports) that switches to the WAT (virtualized) tab and scrolls to that function's body.
+
+### Imports tab
+
+Each row in the **Imports** tab gains:
+
+- A **tooltip** showing the module-qualified name (`module.field`).
+- A **Copy Name** action that copies the qualified name.
+- For function imports, a **Find Usages** action in the context menu: a flat list of the functions that call that import, each entry navigating to the caller's body in the WAT (virtualized) tab. The list is capped at 15 entries. When there are more than 15 callers, or before the call graph finishes computing, a single entry opens the Caller Paths panel listing every usage. The call graph is built off the EDT so the menu stays responsive on large modules.
+
+## Android DEX and ZIP64 (0.12)
+
+- **Android DEX** — `.dex` files open with a basic classes-and-members view.
+- **ZIP64** — archives using the ZIP64 extensions are now supported in the archive viewer.
+
+## Changed
+
+- Hexana's project-view actions (**Hex view**, **Open Archive**, **Compare WASM With…**, and the in-editor **Hex** / offset / structure actions) are now grouped under a single **Hexana** submenu. In IntelliJ IDEA the submenu sits at the top level of the project-view popup. In RustRover and CLion, whose project-view popup is a fixed list that drops third-party top-level contributions, the submenu appears under **Open In > Hexana**. Each action still controls its own visibility.
+- **Compare WASM With…** can now be invoked from Search Everywhere and the keymap, not only from a selected `.wasm` file in the project view. With no `.wasm` pre-selected, it prompts for the first module and then the second.
+- Stability improvements for debugging with Node.js.
+
+## Fixed
+
+- **Top tab tree nodes expand again.** Lazily-generated children (nested component / embedded core module nodes, and a core module's sections expanding into functions) silently showed nothing. The lazy children generator was inheriting the already-cancelled flag from the tree-build coroutine. The generator no longer inherits the cancellation state from the calling coroutine.
+
+## Upgrading to 0.12
+
+No breaking changes. All 0.12 additions are automatic or additive.
+
+- **Static-library archives** are opened the moment you double-click a `.a` or `.lib` in the project view. No configuration is needed.
+- **Component Model diff** becomes available on any Component Model binary when you invoke **Compare WASM With…** — the same action already in your keymap or project-view menu from 0.11.1.
+- **Component Model WAT tab and size breakdown** appear automatically when you open a component binary; the existing tab layout gains the module selector and the corrected tree expansion.
+- **Exports / Imports row affordances** appear in the existing tabs with no configuration.
+- The disassembly used for archive member inspection is the same experimental Capstone backend as for other native binaries. No additional installation is required.
+- Everything runs on your machine. No data is sent anywhere.
+
+## Known limitations in 0.12
+
+- Android DEX support is basic: classes and members are listed, but bytecode decoding and cross-reference navigation are not yet implemented.
+- Archive member disassembly uses the existing experimental native-binary backend. Symbols in COFF `.obj` files compiled without `/Zi` or `/Z7` are not always resolved.
+- Browser debugging still targets Chrome (via the Chrome DevTools Protocol) only; other browsers are not wired for debug.
+- Carryover from 0.11: native-binary support is experimental; the Cranelift / Redline disassembler backend is experimental; Java integration covers Java sources only; quick-fixes are not yet wired on the WebAssembly Java or WIT inspections.
+
+## Earlier releases
+
+- [Hexana 0.11 release notes](changelog-0.11.md) — 0.11 (2026-06-11) and 0.11.1 (2026-06-17): module diff with structural matching, Kotlin/Wasm source navigation, Node.js and browser runtimes, GraalVM Native Image with embedded SBOM and OSV vulnerability reachability.
+- [Hexana 0.10 release notes](changelog-0.10.md) — 0.10 (2026-05-27), plus the 0.10.1–0.10.3 patch line.
+- [Hexana 0.9 release notes](changelog-0.9.md) — 0.9 (2026-05-07), 0.9.1 (2026-05-20).

--- a/docs/jetbrains/features.md
+++ b/docs/jetbrains/features.md
@@ -1,12 +1,12 @@
 ---
 title: Hexana Feature Reference
 description: Complete capability reference for the Hexana IntelliJ plugin, grouped by surface.
-version: "0.11.1"
+version: "0.12"
 ---
 
 # Hexana Feature Reference
 
-This page enumerates every user-visible capability Hexana ships. Capabilities are grouped by *surface* (file type or interaction point), not by chronological release. For per-release changes, see [`changelog-0.11.md`](changelog-0.11.md), [`changelog-0.10.md`](changelog-0.10.md), and the prior [`changelog-0.9.md`](changelog-0.9.md).
+This page enumerates every user-visible capability Hexana ships. Capabilities are grouped by *surface* (file type or interaction point), not by chronological release. For per-release changes, see [`changelog-0.12.md`](changelog-0.12.md), [`changelog-0.11.md`](changelog-0.11.md), [`changelog-0.10.md`](changelog-0.10.md), and the prior [`changelog-0.9.md`](changelog-0.9.md).
 
 ![Hexana opens a `.wasm` file with the structure tabs visible](../images/idea/01-wasm-overview.png)
 
@@ -26,11 +26,17 @@ When Hexana opens a `.wasm` file, it presents a structured editor with the follo
 - Resolved type signature per imported function.
 - Click an entry to jump to its hex offset in the **Hex** tab.
 - Search-as-you-type filter across import names.
+- **(0.12)** Each row shows a tooltip with the module-qualified name (`module.field`).
+- **(0.12)** **Copy Name** context-menu action copies the qualified name.
+- **(0.12)** For function imports, **Find Usages** lists every function that calls the import (resolved from the call graph), capped at 15 entries; each entry navigates to the caller's body in the WAT (virtualized) tab. Beyond 15, or before the call graph finishes computing, the entry opens the Caller Paths panel. The call graph is computed off the EDT.
 
 ### Exports tab
 - Exports listed with the resolved target index and kind.
 - Goto Symbol contributes export names project-wide.
 - Click an entry to jump to its hex offset.
+- **(0.12)** Each row shows a tooltip with the full export name (for names truncated by the column width).
+- **(0.12)** **Copy Name** context-menu action.
+- **(0.12)** **Navigate to Function in WAT** context-menu action (shown only for function exports) switches to the WAT (virtualized) tab and scrolls to that function's body.
 
 ### Functions tab
 - One row per defined function with index, type signature, local count, and code-section offset.
@@ -44,6 +50,7 @@ When Hexana opens a `.wasm` file, it presents a structured editor with the follo
 - Sortable table of the largest functions, data segments, and sections by byte size.
 - Click a row to navigate to the corresponding hex range.
 - Useful first stop when "the binary got bigger" — the top of the list is where the bytes went.
+- **(0.12)** For Component Model binaries, the tree now attributes every nested sub-component and embedded core module with its correct byte count, expanding on demand to internal sections and then to functions, recursively. Previously, a composed component reported most of its bytes as a single opaque block.
 
 ### Hex tab
 - Byte-level view with section annotations.
@@ -64,6 +71,7 @@ When Hexana opens a `.wasm` file, it presents a structured editor with the follo
 - Syntax highlighting and brace matching; IDE zoom respected.
 - Reference-types and bulk-memory instructions rendered.
 - Legacy Exception Handling (`try`, `catch`, `throw`, `rethrow`, `delegate`, `catch_all`) supported alongside the finalised `try_table` proposal.
+- **(0.12)** Component Model binaries: the WAT tab discovers every embedded core module recursively through nested sub-components and renders the selected one with the same three-column offset / bytes / mnemonic layout. A selector switches between modules when a component contains more than one. In-memory component views (such as a submodule opened from a diff) also gain a WAT tab this way.
 
 #### Inline row editing
 
@@ -117,7 +125,16 @@ Modules compiled by the Kotlin/Wasm backend are recognised and made navigable ba
 - **Minified modules** — detected (e.g. Binaryen `--minify-imports-and-exports`); a symbol-map sidecar (`<file>.symbols` from `--emit-symbol-map`, in either function-index or `original => minified` form) restores the original names so functions match by name.
 - **On-demand WAT comparison** — selecting a function opens a side-by-side WAT diff rendered with symbolic names and red/green line-level highlighting, so an unchanged caller of a renumbered function reads identically.
 
-For the full release notes, see [`changelog-0.11.md`](changelog-0.11.md#0111-module-diff-and-kotlinwasm).
+For the full release notes on the core-module diff, see [`changelog-0.11.md`](changelog-0.11.md#0111-module-diff-and-kotlinwasm).
+
+### Component Model diff (0.12)
+
+**Compare WASM With…** now accepts Component Model binaries. Comparing two components opens a submodule view listing each component's embedded submodules (core modules and nested components, found recursively) and classifying each as identical, modified, added, or removed. Clicking a changed pair opens a dedicated tab:
+
+- A **core-module pair** reuses the existing Size Impact / Entities / WAT diff.
+- A **nested-component pair** recurses into the same submodule view.
+
+Submodules are paired by content hash, with positional fallback when hashes do not match.
 
 ## WIT language support
 
@@ -200,6 +217,22 @@ Hexana opens Java archives, class files, and Hotspot JIT dumps as structured doc
 ![JAR file: hex on top, searchable class list below](../images/idea/07-jar-class-list.png)
 
 `.jar`, `.zip`, `.war`, `.apk` archives open with a hex view on top and a searchable, sortable class list below. Click a class to open its decoded bytes in a nested tab. An **Open in… → Hexana** action surfaces from the Project tool window for archive entries, including entries under External Libraries.
+
+### Static-library archives — `.a` and `.lib` (0.12)
+
+<!-- TODO: screenshot for static-library Members view -->
+
+`.a` (Unix `ar`) and `.lib` (Windows COFF import library) archives open as a **Members** list. Each row shows the member name, detected format (ELF / Mach-O / PE / COFF / short-import), and size. The archive's bookkeeping entries (symbol tables, long-names table) are hidden.
+
+Clicking a member extracts the object file to the IDE's temp folder and opens it in the matching disassembly view. Both the Capstone and llvm-objdump backends are available for extracted members. The member tab is titled `archive-name/member-name`; duplicate names get an index suffix.
+
+Archives are detected by `!<arch>\n` content magic, not extension. Plain MSVC import `.lib` files without this header are left to their normal handler.
+
+**Per-function disassembly**: relocatable object files (ELF `.o`, Windows COFF `.obj`/`.o`, Mach-O) carry section-relative symbols. Hexana resolves each symbol's file offset through its owning section so the virtualized Capstone view lists named functions individually. Stripped members fall back to whole-section disassembly.
+
+### Android DEX — `.dex` (0.12)
+
+`.dex` files open with a basic classes-and-members view.
 
 ### JIT dumps
 

--- a/docs/jetbrains/file-types.md
+++ b/docs/jetbrains/file-types.md
@@ -1,7 +1,7 @@
 ---
 title: File Types Registered by Hexana
-description: File types Hexana registers in the IntelliJ Platform — .wasm, .wat, .wit, native binaries (ELF/Mach-O/PE), JVM artifacts (.class, .jar, .war, .apk), and JIT dumps.
-version: "0.11"
+description: File types Hexana registers in the IntelliJ Platform — .wasm, .wat, .wit, native binaries (ELF/Mach-O/PE), JVM artifacts (.class, .jar, .war, .apk), static-library archives (.a/.lib), Android DEX (.dex), and JIT dumps.
+version: "0.12"
 ---
 
 # File Types
@@ -16,7 +16,9 @@ Hexana registers and detects the following file types in the IntelliJ Platform.
 | Native binary | ELF / Mach-O / PE magic bytes (any extension); `.elf`, `.so`, `.dylib`, `.bundle`, `.exe`, `.dll`, `.sys` | Hexana hex + structure + disassembly | `org.jetbrains.hexana.NativeBinaryFileType` |
 | `binary` | `.bin` and other generic-extension fallbacks | Hex view | `org.jetbrains.hexana.BinaryFileType` |
 | JVM class | `.class` | Three-tab class view (header, methods, constant pool) | Handled inside `HexanaFileEditorProvider` |
-| JVM archive | `.jar`, `.zip`, `.war`, `.apk` | Hex view + searchable class list | Handled inside `HexanaFileEditorProvider` |
+| JVM archive | `.jar`, `.zip`, `.war`, `.apk` (including ZIP64) | Hex view + searchable class list | Handled inside `HexanaFileEditorProvider` |
+| Static-library archive (0.12) | `!<arch>\n` magic; `.a`, `.lib` | Members list + per-member disassembly | Handled inside `HexanaFileEditorProvider` |
+| Android DEX (0.12) | `.dex` | Basic classes-and-members view | Handled inside `HexanaFileEditorProvider` |
 | JIT dump | `.jit` | Three-pane symbol / native / bytecode view | Handled inside `HexanaFileEditorProvider` |
 
 Hexana also registers a `fileTypeOverrider` (`HexFileTypeOverrider`) that claims `.wasm`, `.wat`, and `.wit` even when another plugin tries to register the same extension.
@@ -89,6 +91,22 @@ This is the same view used for individual entries when browsing a `.jar` or `.ap
 
 Archives open with a hex view on top and a searchable, sortable class list below. Click any entry to open it in a nested tab using the `.class` view above. The list supports filtering by name and sorting by size, name, or position in the archive.
 
+ZIP64 archives (entries and central-directory records using the ZIP64 extension fields) are supported as of 0.12.
+
+## Static-library archives — `.a`, `.lib` (0.12)
+
+<!-- TODO: screenshot for static-library Members view -->
+
+Unix `ar` archives (`.a`) and Windows COFF import libraries (`.lib`) open as a **Members** list. Detection is by `!<arch>\n` content magic, not extension, so a renamed archive is still recognised and a plain MSVC import `.lib` without that header is left to its normal handler.
+
+Each row in the Members list shows the member name, its detected object format (ELF / Mach-O / PE / COFF / short-import), and its size. The archive's own bookkeeping entries (symbol tables, long-names table) are hidden. Clicking a member extracts the object file to the IDE's temp folder and opens it in the matching disassembly view; because the extracted file is a real on-disk file, both the Capstone and llvm-objdump backends are available. The member tab is titled `archive-name/member-name`; duplicate names receive an index suffix.
+
+For relocatable object files (ELF `.o`, Windows COFF `.obj`/`.o`, Mach-O), the virtualized Capstone view lists each named function individually, with file offsets resolved through the owning section. Stripped members fall back to whole-section disassembly.
+
+## Android DEX — `.dex` (0.12)
+
+`.dex` files open with a basic classes-and-members view listing the classes and their methods.
+
 ## JIT dumps — `.jit`
 
 Hexana ships a bundled JVMTI agent (`libjitview`). When attached to a Java run configuration, it hooks `CompiledMethodLoad` and writes a `.jit` dump on shutdown. Opening the dump gives:
@@ -105,6 +123,6 @@ A catch-all binary file type for content that doesn't match ELF, Mach-O, PE, or 
 
 ## Default editor selection
 
-`HexanaFileEditorProvider` returns a Hexana editor for `.wasm`, native binaries (detected by magic bytes), `.class`, `.jar` / `.war` / `.apk` / `.zip`, and `.jit`. For `.wat` and `.wit`, the platform's default editor (with Hexana's language support applied) is used. For the generic binary type, Hexana's hex view is the default editor.
+`HexanaFileEditorProvider` returns a Hexana editor for `.wasm`, native binaries (detected by magic bytes), `.class`, `.jar` / `.war` / `.apk` / `.zip` (including ZIP64), static-library archives (detected by `!<arch>\n` magic), `.dex`, and `.jit`. For `.wat` and `.wit`, the platform's default editor (with Hexana's language support applied) is used. For the generic binary type, Hexana's hex view is the default editor.
 
 If you have another plugin that conflicts on `.wasm` / `.wat` / `.wit`, `HexFileTypeOverrider` ensures Hexana wins. To disable the override, uninstall or disable the Hexana plugin.

--- a/docs/jetbrains/getting-started.md
+++ b/docs/jetbrains/getting-started.md
@@ -10,7 +10,7 @@ This page covers installation, first launch, and the three main views you will s
 
 ## How do I install Hexana?
 
-1. Open your IntelliJ-based IDE (IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, or PhpStorm).
+1. Open your IntelliJ-based IDE (IntelliJ IDEA 2025.2+, RustRover, WebStorm, CLion, PyCharm, Rider, or PhpStorm).
 2. Open **Settings → Plugins → Marketplace**.
 3. Search for `Hexana` and click **Install**.
 4. Restart the IDE when prompted.

--- a/docs/jetbrains/index.md
+++ b/docs/jetbrains/index.md
@@ -24,6 +24,7 @@ audience: [users]
 | [`js-integration.md`](js-integration.md) | JS / TS users | `WebAssembly.instantiate` imports completion and `.instance.exports` type inference. |
 | [`settings.md`](settings.md) | Users | `Settings → Tools → Hexana`, `Settings → Build, Execution → WASM Runtime`, and Registry-key toggles. |
 | [`troubleshooting.md`](troubleshooting.md) | Users | Common failure modes and resolutions. |
+| [`changelog-0.12.md`](changelog-0.12.md) | All | Release notes for 0.12 (2026-06-24). |
 | [`changelog-0.11.md`](changelog-0.11.md) | All | Release notes for the 0.11 line (0.11, 0.11.1). |
 | [`changelog-0.10.md`](changelog-0.10.md) | All | Release notes for the 0.10 line. |
 | [`changelog-0.9.md`](changelog-0.9.md) | All | Release notes for the 0.9 line. |
@@ -31,14 +32,14 @@ audience: [users]
 
 ## Version and compatibility
 
-- **Plugin version**: 0.11.1.
-- **`since-build`**: defined by `gradle.properties` → `defaultSinceBuild`. Hexana targets IntelliJ Platform 2024.1+.
+- **Plugin version**: 0.12.
+- **`since-build`**: defined by `gradle/intellij-platform.versions.toml` → `defaultSinceBuild = "252"`. Hexana targets IntelliJ Platform 2025.2+.
 - **Optional integrations**: the JavaScript plugin (enables JS interop for `instance.exports`) and the Java module (enables GraalWasm / Chicory completion). Both are loaded when the host IDE bundles them.
 - **Required dependency**: `com.intellij.mcpServer` — Hexana registers its toolset against the platform MCP server.
 
 ## Supported IDEs
 
-IntelliJ IDEA, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm, and any other IDE on IntelliJ Platform 2024.1+ that bundles or installs `com.intellij.mcpServer`. RustRover and CLion users get the natural fit for binary tooling; WebStorm and PhpStorm users get JS interop.
+IntelliJ IDEA, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm, and any other IDE on IntelliJ Platform 2025.2+ that bundles or installs `com.intellij.mcpServer`. RustRover and CLion users get the natural fit for binary tooling; WebStorm and PhpStorm users get JS interop.
 
 A companion **VS Code extension** is published separately on `marketplace.visualstudio.com` and `open-vsx.org`. See the [VS Code section](../vscode/index.md) of this site for that product's documentation.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 ## Products
 
-- **JetBrains IDE plugin** — version 0.10. Compatible with IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
+- **JetBrains IDE plugin** — version 0.12. Compatible with IntelliJ IDEA 2025.2+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm.
 - **VS Code extension** — version 0.2.0. Compatible with VS Code 1.102+, Cursor, VSCodium, Code OSS.
 
 ## Identity
@@ -37,6 +37,8 @@
 - [JS and TS Integration](jetbrains/js-integration.md): WebAssembly.instantiate imports completion and .instance.exports type inference.
 - [Settings](jetbrains/settings.md): IDE settings pages and Registry-key toggles.
 - [Troubleshooting](jetbrains/troubleshooting.md): common failure modes and resolutions.
+- [Changelog 0.12](jetbrains/changelog-0.12.md): release notes for 0.12 (2026-06-24).
+- [Changelog 0.11](jetbrains/changelog-0.11.md): release notes for the 0.11 line (0.11, 0.11.1).
 - [Changelog 0.10](jetbrains/changelog-0.10.md): release notes for 0.10.
 - [Changelog 0.9](jetbrains/changelog-0.9.md): release notes for the 0.9 line.
 
@@ -68,7 +70,7 @@ Yes. Both products are free. Source code is open at github.com/JetBrains/hexana.
 
 ### Which IDEs are supported?
 
-IntelliJ IDEA 2024.1+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm, and any IntelliJ-based IDE on platform 2024.1+ that bundles the MCP server plugin. Plus Visual Studio Code 1.102+ (since VS Code extension 0.1.0) and VS Code-based editors (Cursor, VSCodium, Code OSS, Windsurf) at the same baseline. Earlier VS Code 1.85+ ran the 0.0.x line.
+IntelliJ IDEA 2025.2+, RustRover, WebStorm, CLion, PyCharm, Rider, PhpStorm, and any IntelliJ-based IDE on platform 2025.2+ that bundles the MCP server plugin. Plus Visual Studio Code 1.102+ (since VS Code extension 0.1.0) and VS Code-based editors (Cursor, VSCodium, Code OSS, Windsurf) at the same baseline. Earlier VS Code 1.85+ ran the 0.0.x line.
 
 ### Does Hexana support the Component Model?
 

--- a/docs/vscode/analysis-tabs.md
+++ b/docs/vscode/analysis-tabs.md
@@ -1,7 +1,7 @@
 ---
 title: Hexana for VS Code — Analysis Tab Reference
 description: Per-tab reference for all 11 analysis panels inside the Hexana VS Code editor.
-version: "0.2.0"
+version: "0.5.0"
 ---
 
 # Analysis Tab Reference
@@ -162,6 +162,8 @@ Generates the **WebAssembly Text** representation of the loaded binary and opens
 - Coexistence with any other VS Code WAT extension you have installed.
 
 The conversion runs in the webview via a WASM-based wat printer (`WasmPrinterJs`), so there is no external dependency.
+
+Since **0.5.0** the WAT view uses **virtual scrolling** — only the visible portion of the text is rendered at any given time. For large modules with thousands of functions (e.g. a multi-MB Emscripten or Kotlin/Wasm binary), this keeps initial render and section navigation fast.
 
 The WAT view is read-only and is regenerated on each open. Inline WAT editing — present in the JetBrains plugin — is not yet in the VS Code extension.
 

--- a/docs/vscode/changelog.md
+++ b/docs/vscode/changelog.md
@@ -1,12 +1,26 @@
 ---
 title: Hexana for VS Code — Release Notes
 description: Release notes for the Hexana VS Code extension.
-version: "0.4.0"
+version: "0.5.0"
 ---
 
 # Release Notes — Hexana for VS Code
 
 This page tracks releases of the VS Code extension.
+
+## 0.5.0
+
+Released **2026-06-24**.
+
+### Added
+
+- **Virtualized WAT view.** The WAT tab now uses virtual scrolling for faster section navigation in large modules. Previously the full text was rendered at once; 0.5.0 renders only the visible portion.
+- **Java `.class` and Android DEX file viewing.** The custom editor now opens `.class` and `.dex` files directly by file-type detection, in addition to recognising them as entries inside JAR/ZIP archives (0.3.0). Files open in the hex viewer.
+- **ZIP64 archive support.** Large archives using the ZIP64 format now open in the Hexana editor.
+
+### Changed
+
+- **NodeJS debugging stability.** Improved reliability of the CDP-backed debug path for Node.js, introduced in 0.4.0.
 
 ## 0.4.0
 

--- a/docs/vscode/features.md
+++ b/docs/vscode/features.md
@@ -1,7 +1,7 @@
 ---
 title: Hexana for VS Code — Feature Reference
 description: Complete capability reference for the Hexana VS Code extension.
-version: "0.4.0"
+version: "0.5.0"
 ---
 
 # Hexana for VS Code — Feature Reference
@@ -16,7 +16,7 @@ Since **0.4.0** the hex viewer supports **in-place byte editing**: select a byte
 
 ### Automatic binary kind detection
 
-Four kinds are detected and badged in the editor toolbar:
+Five kinds are detected and badged in the editor toolbar:
 
 | Badge | Detection |
 |---|---|
@@ -24,6 +24,7 @@ Four kinds are detected and badged in the editor toolbar:
 | `component` | Component Model binary (magic `\0asm`, version 0x0a, layer 1). |
 | `wasm` | Falls back to generic when neither kind matches but the file is otherwise WebAssembly. |
 | `native` | ELF, Mach-O, or PE binary detected from magic bytes. |
+| `class` / `dex` | Java `.class` file or Android DEX file, opened directly in the hex viewer (0.5.0). |
 
 Tab availability adapts per kind — Component Model files surface a **Modules** tab; core modules surface **Functions**, **Data**, **Custom**, **Monos**, **Garbage**; native binaries surface a structure tab covering sections, segments, and symbols.
 
@@ -57,8 +58,13 @@ Common extensions are recognised (`.elf`, `.so`, `.dylib`, `.bundle`, `.exe`, `.
 
 - Click an entry that is itself a recognised binary — `.wasm`, `.class`, a native binary, or a nested archive — to open it in a new Hexana editor tab.
 - Decompression happens in the extension host; entries are read on demand, so large archives open without unpacking everything up front.
+- **ZIP64 archives (0.5.0)** — large archives using the ZIP64 format open without issue.
 
 The decoded three-tab `.class` view (header / methods / constant pool) remains JetBrains-only — in VS Code a `.class` entry opens in the hex viewer. See [What this version does not do](#what-this-version-does-not-do-yet).
+
+## Java class files and Android DEX files (0.5.0+)
+
+Java `.class` files and Android DEX (`.dex`) files open directly in the Hexana custom editor by file-type detection, without needing to be inside a JAR or ZIP archive. Both formats open in the hex viewer. The full decoded class view (header / methods / constant pool) — available in the JetBrains plugin — is not present in the VS Code extension. See [What this version does not do](#what-this-version-does-not-do-yet).
 
 ## Analysis tabs
 
@@ -77,6 +83,8 @@ Up to 11 tabs inside the same editor, surfaced by binary kind. All tables are **
 | Garbage | ✓ | — | — |
 | Modules | — | ✓ | — |
 | WAT | ✓ | ✓ | — |
+
+The WAT tab uses **virtual scrolling** since 0.5.0 — only the visible portion of the text is rendered, which keeps navigation fast in large modules. See [`analysis-tabs.md#wat`](analysis-tabs.md#wat) for details.
 
 ## Run support
 

--- a/docs/vscode/getting-started.md
+++ b/docs/vscode/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Hexana for VS Code
 description: How to install the Hexana VS Code extension, open a WebAssembly file, and find the main views.
-version: "0.4.0"
+version: "0.5.0"
 ---
 
 # Getting Started with Hexana for VS Code

--- a/docs/vscode/index.md
+++ b/docs/vscode/index.md
@@ -1,13 +1,13 @@
 ---
 title: Hexana VS Code Extension — Documentation
 description: User and contributor documentation for the Hexana VS Code extension.
-version: "0.4.0"
+version: "0.5.0"
 audience: [users]
 ---
 
 # Hexana — VS Code Extension Documentation
 
-**Hexana** is a Visual Studio Code extension by JetBrains for inspecting and running WebAssembly binaries — and, since 0.2.0, native binaries (ELF, Mach-O, PE); since 0.3.0, JVM archives (`.jar`, `.zip`, `.war`, `.apk`) as well. Open any `.wasm` file and Hexana replaces the default editor with a Compose-for-Web webview: a virtual-scrolling hex viewer alongside up to **11 structural-analysis tabs** (Summary, Exports, Imports, Functions, Data, Custom, Top, Monos, Garbage, Modules, WAT). Native binaries and archives open with the same hex + structure layout. Since 0.4.0 the hex viewer also supports **in-place byte editing** (overwrite-only — the file size never changes). Run modules through **Wasmtime**, **WAMR**, **GraalVM**, **Node.js**, or the **browser**, **debug** them (experimental) — `lldb`-backed on Wasmtime / WAMR (LLVM 22.1+), and, since 0.4.0, CDP-backed on Node.js and Chrome — resolve Component Model dependencies automatically, and drive analysis from an AI tool over the on-demand-downloaded **MCP server**.
+**Hexana** is a Visual Studio Code extension by JetBrains for inspecting and running WebAssembly binaries — and, since 0.2.0, native binaries (ELF, Mach-O, PE); since 0.3.0, JVM archives (`.jar`, `.zip`, `.war`, `.apk`) as well. Open any `.wasm` file and Hexana replaces the default editor with a Compose-for-Web webview: a virtual-scrolling hex viewer alongside up to **11 structural-analysis tabs** (Summary, Exports, Imports, Functions, Data, Custom, Top, Monos, Garbage, Modules, WAT). Native binaries and archives open with the same hex + structure layout. Since 0.4.0 the hex viewer also supports **in-place byte editing** (overwrite-only — the file size never changes). Since 0.5.0 the WAT tab uses **virtual scrolling** for faster navigation in large modules, and the editor also opens Java `.class` and Android DEX files directly, as well as ZIP64 archives. Run modules through **Wasmtime**, **WAMR**, **GraalVM**, **Node.js**, or the **browser**, **debug** them (experimental) — `lldb`-backed on Wasmtime / WAMR (LLVM 22.1+), and, since 0.4.0, CDP-backed on Node.js and Chrome — resolve Component Model dependencies automatically, and drive analysis from an AI tool over the on-demand-downloaded **MCP server**.
 
 > Looking for the IntelliJ Platform plugin? See the [JetBrains IDEs section](../jetbrains/index.md). The VS Code and JetBrains products share the same WASM parser core but differ in language-support depth, run integrations, and target audience.
 
@@ -26,7 +26,7 @@ audience: [users]
 
 ## Version and compatibility
 
-- **Extension version**: 0.3.0.
+- **Extension version**: 0.5.0.
 - **VS Code requirement**: `^1.102.0` — required for the MCP-server registration API used by the on-demand MCP integration. Older 0.0.x releases ran on 1.85+.
 - **Optional Java**: 21 or newer for the MCP server. The server is downloaded on demand on first MCP use; set `hexana.mcp.javaHome` to point at a specific JDK if `JAVA_HOME` / `PATH` do not surface one.
 - **Optional LLVM**: 22.1 or newer for the experimental debug path (Wasmtime + WAMR, `lldb` under the hood).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - JavaScript & TypeScript: jetbrains/js-integration.md
       - Settings: jetbrains/settings.md
       - Troubleshooting: jetbrains/troubleshooting.md
+      - Changelog 0.12: jetbrains/changelog-0.12.md
       - Changelog 0.11: jetbrains/changelog-0.11.md
       - Changelog 0.10: jetbrains/changelog-0.10.md
       - Changelog 0.9: jetbrains/changelog-0.9.md


### PR DESCRIPTION
Updates the public docs site for the **IntelliJ plugin 0.12** and **VS Code extension 0.5.0** releases.

## IntelliJ 0.12 (new `docs/jetbrains/changelog-0.12.md` + feature pages)
- Static-library archives (`.a`/`.lib`) open to a **Members** list, with per-function disassembly of extracted object files (Capstone + llvm-objdump).
- **Compare WASM With…** extended to Component Model binaries (recursive submodule diff); Component Model **WAT (virtualized)** tab; full Component Model breakdown in the **Top** size profiler.
- **Exports** / **Imports** per-row affordances: full-name tooltip, **Copy Name**, **Navigate to Function in WAT** (exports), **Find Usages** (function imports).
- Basic Android DEX support; ZIP64 archives; consolidated **Hexana** project-view submenu; **Compare WASM With…** from Search Everywhere/keymap; Top tree lazy-expand fix.

## VS Code 0.5.0 (`docs/vscode/*`)
- Virtualized WAT view, Java `.class` + Android DEX viewing, ZIP64, NodeJS debug stability.

## Notes
- **No re-documentation of prior point releases.** 0.12's changelog repeats the entire 0.11.1 diff feature set verbatim, and 0.5.0 references 0.4.0; those are already documented on `main`. The new pages reference them only as the features 0.12 / 0.5.0 *extend*.
- **Compatibility floor corrected: 2024.1+ → 2025.2+.** `gradle/intellij-platform.versions.toml` has `defaultSinceBuild = "252"` (2025.2) on both 0.11 and 0.12; the previous "2024.1+" claim was incorrect (the plugin will not install below 2025.2). Stale version pins bumped (llms.txt plugin 0.10 → 0.12, VS Code index 0.3.0 → 0.5.0).
- No new screenshots; new sections use `<!-- TODO -->` placeholders rather than referencing nonexistent images. All existing image and internal-link references verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)